### PR TITLE
Remove root stream length check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,6 +325,16 @@ impl<F> CompoundFile<F> {
         if root_entry.name != consts::ROOT_DIR_NAME {
             invalid_data!("Malformed directory (root name)");
         }
+        let expected_root_stream_len =
+            consts::MINI_SECTOR_LEN as u64 * self.minifat.len() as u64;
+        if root_entry.stream_len < expected_root_stream_len {
+            invalid_data!(
+                "Malformed directory (root stream len is {}, but \
+                        should be >= {})",
+                root_entry.stream_len,
+                expected_root_stream_len
+            );
+        }
         if root_entry.stream_len % consts::MINI_SECTOR_LEN as u64 != 0 {
             invalid_data!(
                 "Malformed directory (root stream len is {}, but \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,16 +325,6 @@ impl<F> CompoundFile<F> {
         if root_entry.name != consts::ROOT_DIR_NAME {
             invalid_data!("Malformed directory (root name)");
         }
-        let expected_root_stream_len =
-            consts::MINI_SECTOR_LEN as u64 * self.minifat.len() as u64;
-        if root_entry.stream_len != expected_root_stream_len {
-            invalid_data!(
-                "Malformed directory (root stream len is {}, but \
-                           should be {})",
-                root_entry.stream_len,
-                expected_root_stream_len
-            );
-        }
         if root_entry.stream_len % consts::MINI_SECTOR_LEN as u64 != 0 {
             invalid_data!(
                 "Malformed directory (root stream len is {}, but \


### PR DESCRIPTION
When trying to read MSI files that are part of the Window SDK install (eg. <https://download.visualstudio.microsoft.com/download/pr/100107594/d176ecb4240a304d1a2af2391e8965d4/Windows%20SDK%20Desktop%20Headers%20x86-x86_en-us.msi>), basically all of them fail this check. When the check is removed, rust-msi is able to give the same results as msiinfo, so it feels like it is just too strict.