### PR TITLE
Fix panics when opening invalid files

### DIFF
--- a/src/internal/directory.rs
+++ b/src/internal/directory.rs
@@ -164,6 +164,9 @@ impl<F> Directory<F> {
     }
 
     fn validate(&self) -> io::Result<()> {
+        if self.dir_entries.is_empty() {
+            malformed!("no entries exist");
+        }
         let root_entry = self.root_dir_entry();
         if root_entry.name != consts::ROOT_DIR_NAME {
             malformed!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,6 +359,7 @@ impl<F: Read + Seek> CompoundFile<F> {
             fat.pop();
         }
 
+        let fat_len = fat.len();
         let mut allocator =
             Allocator::new(sectors, difat_sector_ids, difat, fat)?;
 
@@ -388,6 +389,12 @@ impl<F: Read + Seek> CompoundFile<F> {
                         header.version,
                     )?);
                 }
+            }
+            if current_difat_sector >= fat_len as u32 {
+                invalid_data!(
+                    "DIFAT chain includes invalid fat index {}",
+                    current_difat_sector
+                );
             }
             current_dir_sector = allocator.next(current_dir_sector);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ impl<F: Read + Seek> CompoundFile<F> {
                     )?);
                 }
             }
-            if current_difat_sector >= fat_len as u32 {
+            if current_difat_sector as usize >= fat_len {
                 invalid_data!(
                     "DIFAT chain includes invalid fat index {}",
                     current_difat_sector


### PR DESCRIPTION
This fixes two cases in which certain invalid aspects of CFB files will end in panics due to OOBs.

### Repro ([panics.zip](https://github.com/mdsteele/rust-cfb/files/8229673/panics.zip))
```Rust
use std::io::{Cursor, Read};
use cfb::CompoundFile;
use std::fs::File;

fn main() {
    for path in ["invalid_fat_index", "no_entries"] {
        let mut file = File::open(path).unwrap();
        let mut buffer = Vec::new();
        file.read_to_end(&mut buffer).unwrap();
        CompoundFile::open(Cursor::new(buffer));
    }
}
```

When running, `invalid_fat_index` will panic when parsing:
`thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 1'`

And `no_entries` will panic as well:
`thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0'`

With these updates, both panics are fixed. I'm not sure if this addresses all panics brought up in other issues like #18 just yet, but it's a start.