### PR TITLE
issues/34 Fixed validation in minialloc

### DIFF
--- a/src/internal/entry.rs
+++ b/src/internal/entry.rs
@@ -240,9 +240,13 @@ mod tests {
         )
         .unwrap();
         let directory = Directory::new(allocator, dir_entries, 1).unwrap();
-        let minialloc =
-            MiniAllocator::new(directory, vec![], consts::END_OF_CHAIN)
-                .unwrap();
+        let minialloc = MiniAllocator::new(
+            directory,
+            vec![],
+            consts::END_OF_CHAIN,
+            Validation::Strict,
+        )
+        .unwrap();
         Rc::new(RefCell::new(minialloc))
     }
 

--- a/src/internal/header.rs
+++ b/src/internal/header.rs
@@ -1,6 +1,8 @@
-use crate::internal::{consts, Version};
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Read, Write};
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+
+use crate::internal::{consts, Version};
 
 //===========================================================================//
 
@@ -153,8 +155,9 @@ impl Header {
 
 #[cfg(test)]
 mod tests {
-    use super::Header;
     use crate::internal::{consts, Version};
+
+    use super::Header;
 
     fn make_valid_header() -> Header {
         let mut header = Header {


### PR DESCRIPTION
@mdsteele hello!

1. Removed `except`
2. Validation is less strict in `MiniAllocator`

Closes: https://github.com/mdsteele/rust-cfb/issues/34