### PR TITLE
`open_stream` as `mut` and `read_stream` as non-`mut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,15 @@ impl<F: Seek> CompoundFile<F> {
         self.open_stream_with_path(path.as_ref())
     }
 
-    fn open_stream_with_path(&mut self, path: &Path) -> io::Result<Stream<F>> {
+    /// Rads an existing stream in the compound file for reading
+    pub fn read_stream<P: AsRef<Path>>(
+        &self,
+        path: P,
+    ) -> io::Result<Stream<F>> {
+        self.open_stream_with_path(path.as_ref())
+    }
+
+    fn open_stream_with_path(&self, path: &Path) -> io::Result<Stream<F>> {
         let names = internal::path::name_chain_from_path(path)?;
         let path = internal::path::path_from_name_chain(&names);
         let stream_id = match self.stream_id_for_name_chain(&names) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ impl<F: Seek> CompoundFile<F> {
         self.open_stream_with_path(path.as_ref())
     }
 
-    /// Rads an existing stream in the compound file for reading
+    /// Reads an existing stream in the compound file for reading
     pub fn read_stream<P: AsRef<Path>>(
         &self,
         path: P,


### PR DESCRIPTION
Hi,

while trying to iterate over `read_root_storage`, I encountered that `open_stream` borrows `&mut self` and cannot be easily used with the immutable borrow of `read_root_storage`.

Have you considered a `read_stream` that borrows immutable self? Is there a scenario where that wouldn't work?