### PR TITLE
Add `Debug` implementation for `CompoundFile`

### DIFF
--- a/src/internal/alloc.rs
+++ b/src/internal/alloc.rs
@@ -43,6 +43,10 @@ impl<F> Allocator<F> {
         self.sectors.version()
     }
 
+    pub fn inner(&self) -> &F {
+        self.sectors.inner()
+    }
+
     pub fn sector_len(&self) -> usize {
         self.sectors.sector_len()
     }

--- a/src/internal/directory.rs
+++ b/src/internal/directory.rs
@@ -42,6 +42,10 @@ impl<F> Directory<F> {
         self.allocator.version()
     }
 
+    pub fn inner(&self) -> &F {
+        self.allocator.inner()
+    }
+
     pub fn sector_len(&self) -> usize {
         self.allocator.sector_len()
     }

--- a/src/internal/minialloc.rs
+++ b/src/internal/minialloc.rs
@@ -45,6 +45,10 @@ impl<F> MiniAllocator<F> {
         self.directory.version()
     }
 
+    pub fn inner(&self) -> &F {
+        self.directory.inner()
+    }
+
     pub fn next_mini_sector(&self, sector_id: u32) -> io::Result<u32> {
         let index = sector_id as usize;
         if index >= self.minifat.len() {

--- a/src/internal/sector.rs
+++ b/src/internal/sector.rs
@@ -37,6 +37,10 @@ impl<F> Sectors<F> {
     pub fn into_inner(self) -> F {
         self.inner
     }
+
+    pub fn inner(&self) -> &F {
+        &self.inner
+    }
 }
 
 impl<F: Seek> Sectors<F> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
 #![warn(missing_docs)]
 
 use std::cell::{Ref, RefCell, RefMut};
+use std::fmt;
 use std::fs;
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
@@ -961,6 +962,12 @@ impl<F: Read + Write + Seek> CompoundFile<F> {
     /// Flushes all changes to the underlying file.
     pub fn flush(&mut self) -> io::Result<()> {
         self.minialloc_mut().flush()
+    }
+}
+
+impl<F: fmt::Debug> fmt::Debug for CompoundFile<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CompoundFile").field(self.minialloc().inner()).finish()
     }
 }
 


### PR DESCRIPTION
This adds a `Debug` implementation for `CompoundFile` using the debug implementation of `F`. For a file this looks about like:

```
CompoundFile(File (fd: 3, path: "/foo/bar", read: true, write: false})
```