### PR TITLE
Make CompoundFile implement Send + Sync

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -769,3 +769,18 @@ fn drop_compound_file_with_stream_open() -> io::Result<()> {
 }
 
 //===========================================================================//
+// Tests for asserting Send + Sync:
+
+#[test]
+fn test_compound_file_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<CompoundFile<std::fs::File>>();
+}
+
+#[test]
+fn test_compound_file_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<CompoundFile<std::fs::File>>();
+}
+
+//===========================================================================//


### PR DESCRIPTION
This was done by refactoring code to use `Arc<RwLock>` instead of `Rc<RefCell>`.