### PR TITLE
fix: num_dir_sectors

### DIFF
--- a/src/internal/directory.rs
+++ b/src/internal/directory.rs
@@ -426,13 +426,18 @@ impl<F: Write + Seek> Directory<F> {
     fn update_num_dir_sectors(&mut self) -> io::Result<()> {
         let start_sector = self.dir_start_sector;
         if self.version() == Version::V4 {
-            let num_dir_sectors = self.count_directory_sectors(start_sector)?;
-            self.seek_within_header(40)?.write_u32::<LittleEndian>(num_dir_sectors)?;
+            let num_dir_sectors =
+                self.count_directory_sectors(start_sector)?;
+            self.seek_within_header(40)?
+                .write_u32::<LittleEndian>(num_dir_sectors)?;
         }
         Ok(())
     }
 
-    fn count_directory_sectors(&mut self, start_sector: u32) -> io::Result<u32> {
+    fn count_directory_sectors(
+        &mut self,
+        start_sector: u32,
+    ) -> io::Result<u32> {
         let mut num_dir_sectors = 1;
         let mut next_sector = self.allocator.next(start_sector)?;
         while next_sector != consts::END_OF_CHAIN {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -997,7 +997,7 @@ impl<F: fmt::Debug> fmt::Debug for CompoundFile<F> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+    use std::io::{self, Cursor, Seek, SeekFrom};
     use std::mem::size_of;
     use std::path::Path;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,7 +495,10 @@ impl<F: Read + Seek> CompoundFile<F> {
         let mut current_dir_sector = header.first_dir_sector;
         let mut dir_sector_count = 1;
         while current_dir_sector != consts::END_OF_CHAIN {
-            if validation.is_strict() && header.version == Version::V4 && dir_sector_count > header.num_dir_sectors {
+            if validation.is_strict()
+                && header.version == Version::V4
+                && dir_sector_count > header.num_dir_sectors
+            {
                 invalid_data!(
                     "Directory chain includes at least {} sectors which is greater than header num_dir_sectors {}",
                     dir_sector_count,

--- a/tests/malformed.rs
+++ b/tests/malformed.rs
@@ -478,7 +478,7 @@ fn invalid_num_dir_sectors_issue_52() {
     // update the header and set num_dir_sectors = 1 instead of 2
     let mut cursor = comp.into_inner();
     cursor.seek(SeekFrom::Start(40)).unwrap();
-    cursor.write_all(&[0x01, 0x00, 0x00, 0x00]).unwrap();
+    cursor.write_u32::<LittleEndian>(1).unwrap();
     cursor.flush().unwrap();
 
     // Read the file back in.

--- a/tests/malformed.rs
+++ b/tests/malformed.rs
@@ -460,7 +460,7 @@ fn open_strict_difat_terminate_freesect() {
 /// Regression test for https://github.com/mdsteele/rust-cfb/issues/52.
 #[test]
 #[should_panic(
-expected = "Directory chain includes at least 2 sectors which is greater than header num_dir_sectors 1"
+    expected = "Directory chain includes at least 2 sectors which is greater than header num_dir_sectors 1"
 )]
 fn invalid_num_dir_sectors_issue_52() {
     // Create a CFB file with 2 sectors for the directory.

--- a/tests/malformed.rs
+++ b/tests/malformed.rs
@@ -456,3 +456,31 @@ fn open_difat_terminate_freesect() {
 fn open_strict_difat_terminate_freesect() {
     CompoundFile::open_strict(difat_terminate_in_freesect()).unwrap();
 }
+
+/// Regression test for https://github.com/mdsteele/rust-cfb/issues/52.
+#[test]
+#[should_panic(
+expected = "Directory chain includes at least 2 sectors which is greater than header num_dir_sectors 1"
+)]
+fn invalid_num_dir_sectors_issue_52() {
+    // Create a CFB file with 2 sectors for the directory.
+    let cursor = Cursor::new(Vec::new());
+    let mut comp = CompoundFile::create(cursor).unwrap();
+    // root + 31 entries in the first sector
+    // 1 stream entry in the second sector
+    for i in 0..32 {
+        let path = format!("stream{}", i);
+        let path = Path::new(&path);
+        comp.create_stream(path).unwrap();
+    }
+    comp.flush().unwrap();
+
+    // update the header and set num_dir_sectors = 1 instead of 2
+    let mut cursor = comp.into_inner();
+    cursor.seek(SeekFrom::Start(40)).unwrap();
+    cursor.write_all(&[0x01, 0x00, 0x00, 0x00]).unwrap();
+    cursor.flush().unwrap();
+
+    // Read the file back in.
+    CompoundFile::open_strict(cursor).unwrap();
+}


### PR DESCRIPTION
Correctly update file header `num_dir_sectors` when new directory sectors are added.

fixes #52