### PR TITLE
Make directory processing more permissive

### DIFF
--- a/src/internal/entry.rs
+++ b/src/internal/entry.rs
@@ -150,8 +150,12 @@ impl<'a, F> Entries<'a, F> {
     fn stack_left_spine(&mut self, parent_path: &Path, mut current_id: u32) {
         let minialloc = self.minialloc.read().unwrap();
         while current_id != consts::NO_STREAM {
-            self.stack.push((parent_path.to_path_buf(), current_id, true));
-            current_id = minialloc.dir_entry(current_id).left_sibling;
+            if let Some(dir_entry) = minialloc.try_dir_entry(current_id) {
+                self.stack.push((parent_path.to_path_buf(), current_id, true));
+                current_id = dir_entry.left_sibling;
+            } else {
+                break;
+            }
         }
     }
 }

--- a/src/internal/minialloc.rs
+++ b/src/internal/minialloc.rs
@@ -96,6 +96,10 @@ impl<F> MiniAllocator<F> {
         self.directory.root_dir_entry()
     }
 
+    pub fn try_dir_entry(&self, stream_id: u32) -> Option<&DirEntry> {
+        self.directory.try_dir_entry(stream_id)
+    }
+
     pub fn dir_entry(&self, stream_id: u32) -> &DirEntry {
         self.directory.dir_entry(stream_id)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,12 +511,16 @@ impl<F: Read + Seek> CompoundFile<F> {
                     current_dir_sector
                 );
             } else if current_dir_sector >= num_sectors {
-                invalid_data!(
-                    "Directory chain includes sector index {}, but sector \
-                     count is only {}",
-                    current_dir_sector,
-                    num_sectors
-                );
+                if validation.is_strict() {
+                    invalid_data!(
+                        "Directory chain includes sector index {}, but sector \
+                         count is only {}",
+                        current_dir_sector,
+                        num_sectors
+                    );
+                } else {
+                    break;
+                }
             }
             if seen_dir_sectors.contains(&current_dir_sector) {
                 invalid_data!(


### PR DESCRIPTION
Sometimes we are to open CFB files with corrupted directory structure. 

In this PR we skip weird dir entries (in permissive mode) instead of returning an error.

Mostly inspired by [`compoundfiles.entities`](https://github.com/waveform-computing/compoundfiles/blob/master/compoundfiles/entities.py)