### PR TITLE
Fix name compare

### DIFF
--- a/src/internal/alloc.rs
+++ b/src/internal/alloc.rs
@@ -78,7 +78,7 @@ impl<F> Allocator<F> {
         &mut self,
         start_sector_id: u32,
         init: SectorInit,
-    ) -> io::Result<Chain<F>> {
+    ) -> io::Result<Chain<'_, F>> {
         Chain::new(self, start_sector_id, init)
     }
 
@@ -157,11 +157,14 @@ impl<F: Seek> Allocator<F> {
     pub fn seek_within_header(
         &mut self,
         offset_within_header: u64,
-    ) -> io::Result<Sector<F>> {
+    ) -> io::Result<Sector<'_, F>> {
         self.sectors.seek_within_header(offset_within_header)
     }
 
-    pub fn seek_to_sector(&mut self, sector_id: u32) -> io::Result<Sector<F>> {
+    pub fn seek_to_sector(
+        &mut self,
+        sector_id: u32,
+    ) -> io::Result<Sector<'_, F>> {
         self.sectors.seek_to_sector(sector_id)
     }
 
@@ -169,7 +172,7 @@ impl<F: Seek> Allocator<F> {
         &mut self,
         sector_id: u32,
         offset_within_sector: u64,
-    ) -> io::Result<Sector<F>> {
+    ) -> io::Result<Sector<'_, F>> {
         self.sectors.seek_within_sector(sector_id, offset_within_sector)
     }
 
@@ -179,7 +182,7 @@ impl<F: Seek> Allocator<F> {
         subsector_index_within_sector: u32,
         subsector_len: usize,
         offset_within_subsector: u64,
-    ) -> io::Result<Sector<F>> {
+    ) -> io::Result<Sector<'_, F>> {
         let subsector_start =
             subsector_index_within_sector as usize * subsector_len;
         let offset_within_sector =

--- a/src/internal/directory.rs
+++ b/src/internal/directory.rs
@@ -77,7 +77,7 @@ impl<F> Directory<F> {
         &mut self,
         start_sector_id: u32,
         init: SectorInit,
-    ) -> io::Result<Chain<F>> {
+    ) -> io::Result<Chain<'_, F>> {
         self.allocator.open_chain(start_sector_id, init)
     }
 
@@ -200,11 +200,14 @@ impl<F: Seek> Directory<F> {
     pub fn seek_within_header(
         &mut self,
         offset_within_header: u64,
-    ) -> io::Result<Sector<F>> {
+    ) -> io::Result<Sector<'_, F>> {
         self.allocator.seek_within_header(offset_within_header)
     }
 
-    fn seek_to_dir_entry(&mut self, stream_id: u32) -> io::Result<Sector<F>> {
+    fn seek_to_dir_entry(
+        &mut self,
+        stream_id: u32,
+    ) -> io::Result<Sector<'_, F>> {
         self.seek_within_dir_entry(stream_id, 0)
     }
 
@@ -212,7 +215,7 @@ impl<F: Seek> Directory<F> {
         &mut self,
         stream_id: u32,
         offset_within_dir_entry: usize,
-    ) -> io::Result<Sector<F>> {
+    ) -> io::Result<Sector<'_, F>> {
         let dir_entries_per_sector =
             self.version().dir_entries_per_sector() as u32;
         let index_within_sector = stream_id % dir_entries_per_sector;

--- a/src/internal/direntry.rs
+++ b/src/internal/direntry.rs
@@ -16,7 +16,7 @@ macro_rules! malformed {
 
 //===========================================================================//
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DirEntry {
     pub name: String,
     pub obj_type: ObjType,

--- a/src/internal/header.rs
+++ b/src/internal/header.rs
@@ -6,6 +6,7 @@ use crate::internal::{consts, Validation, Version};
 
 //===========================================================================//
 
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Header {
     pub version: Version,
     pub num_dir_sectors: u32,

--- a/src/internal/minialloc.rs
+++ b/src/internal/minialloc.rs
@@ -81,14 +81,14 @@ impl<F> MiniAllocator<F> {
         &mut self,
         start_sector_id: u32,
         init: SectorInit,
-    ) -> io::Result<Chain<F>> {
+    ) -> io::Result<Chain<'_, F>> {
         self.directory.open_chain(start_sector_id, init)
     }
 
     pub fn open_mini_chain(
         &mut self,
         start_sector_id: u32,
-    ) -> io::Result<MiniChain<F>> {
+    ) -> io::Result<MiniChain<'_, F>> {
         MiniChain::new(self, start_sector_id)
     }
 
@@ -148,7 +148,7 @@ impl<F: Seek> MiniAllocator<F> {
         &mut self,
         mini_sector: u32,
         offset_within_mini_sector: u64,
-    ) -> io::Result<Sector<F>> {
+    ) -> io::Result<Sector<'_, F>> {
         debug_assert!(
             offset_within_mini_sector < consts::MINI_SECTOR_LEN as u64
         );

--- a/src/internal/stream.rs
+++ b/src/internal/stream.rs
@@ -40,9 +40,9 @@ impl<F> Stream<F> {
     }
 
     fn minialloc(&self) -> io::Result<Arc<RwLock<MiniAllocator<F>>>> {
-        self.minialloc.upgrade().ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "CompoundFile was dropped")
-        })
+        self.minialloc
+            .upgrade()
+            .ok_or_else(|| io::Error::other("CompoundFile was dropped"))
     }
 
     /// Returns the current length of the stream, in bytes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,9 @@ impl<F: Read + Seek> CompoundFile<F> {
         }
         inner.seek(SeekFrom::Start(0))?;
 
+        // 2.2 Compound File Header
         let header = Header::read_from(&mut inner, validation)?;
+        // Major Version
         let sector_len = header.version.sector_len();
         if inner_len
             > (consts::MAX_REGULAR_SECTOR as u64 + 1) * (sector_len as u64)

--- a/tests/malformed.rs
+++ b/tests/malformed.rs
@@ -73,7 +73,7 @@ fn invalid_mini_sector_issue_16() {
     // Corrupt the starting mini sector ID of the stream.  Due to how we
     // constructed the CFB file, this will be at byte 116 of the second
     // 128-byte directory entry in the third sector of the CFB file.
-    let offset = 116 + 128 * 1 + (version.sector_len() as u64) * 2;
+    let offset = 116 + 128 + (version.sector_len() as u64) * 2;
     cursor.seek(SeekFrom::Start(offset)).unwrap();
     cursor.write_u32::<LittleEndian>(123456789).unwrap();
 
@@ -469,7 +469,7 @@ fn invalid_num_dir_sectors_issue_52() {
     // root + 31 entries in the first sector
     // 1 stream entry in the second sector
     for i in 0..32 {
-        let path = format!("stream{}", i);
+        let path = format!("stream{i}");
         let path = Path::new(&path);
         comp.create_stream(path).unwrap();
     }


### PR DESCRIPTION
#60 seems to be hitting a minute detail of the spec about the red-black tree sorting relationship.

The standard specifies that the utf16 characters should be uppercased by using the "simple case conversion variant (simple case foldings)", which doesn't make sense to me, since case folding Unicode conversion does not necessarily yield the uppercase version. Uppercasing ß yields SS which then is no longer Ö < ß but Ö > SS. Case folding conversion AFAIK yields ss, but it is also the case that Ö > ss, so I don't see how to read the standard in a way that makes the provided file standard compliant.