### PR TITLE
Free sectors may appear anywhere in FAT

### DIFF
--- a/src/internal/alloc.rs
+++ b/src/internal/alloc.rs
@@ -83,7 +83,9 @@ impl<F> Allocator<F> {
     }
 
     fn validate(&mut self, validation: Validation) -> io::Result<()> {
-        if self.fat.len() > self.sectors.num_sectors() as usize {
+        let non_free =
+            self.fat.iter().filter(|&&i| i != consts::FREE_SECTOR).count();
+        if non_free > self.sectors.num_sectors() as usize {
             malformed!(
                 "FAT has {} entries, but file has only {} sectors",
                 self.fat.len(),

--- a/src/internal/alloc.rs
+++ b/src/internal/alloc.rs
@@ -85,7 +85,9 @@ impl<F> Allocator<F> {
     fn validate(&mut self, validation: Validation) -> io::Result<()> {
         let non_free =
             self.fat.iter().filter(|&&i| i != consts::FREE_SECTOR).count();
-        if non_free > self.sectors.num_sectors() as usize {
+        if validation.is_strict()
+            && non_free > self.sectors.num_sectors() as usize
+        {
             malformed!(
                 "FAT has {} entries, but file has only {} sectors",
                 self.fat.len(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1316,9 +1316,13 @@ mod tests {
 
     #[test]
     fn too_many_fat_entries() {
+        use std::io::Write;
+
         let cfb = make_cfb_with_inconsistent_difat_entries().unwrap();
 
-        CompoundFile::open(Cursor::new(cfb)).unwrap();
+        let mut cfb = CompoundFile::open(Cursor::new(cfb)).unwrap();
+        let mut f = cfb.create_stream("stream").unwrap();
+        f.write_all(&vec![0; 100 * 1024 * 1024]).unwrap();
     }
 }
 


### PR DESCRIPTION
~~While investigating #63 we found a file that has `FREE_SECTOR` in the middle of the FAT.
Since the location and number of `FREE_SECTOR` is arbitrary, it should be possible to hit this error if `FREE_SECTOR` are counted as a legitimate sector that must exist in the CFB.~~

Don't know what I was thinking, having `FREE_SECTOR` in the middle of the file is also going to increase the file size and thus `num_sectors`.