### PR TITLE
Off by one error in DIFAT

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,7 +500,11 @@ impl<F: Read + Seek> CompoundFile<F> {
         // case above, we can remove these even if it makes the number of FAT
         // entries less than the number of sectors in the file; the allocator
         // will implicitly treat these extra sectors as free.
-        while fat.last() == Some(&consts::FREE_SECTOR) {
+        while fat.last() == Some(&consts::FREE_SECTOR)
+            // strip DIFAT_SECTOR from the end
+            || !validation.is_strict()
+                && fat.len() > sectors.num_sectors() as usize && fat.last() == Some(&consts::DIFAT_SECTOR)
+        {
             fat.pop();
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1320,9 +1320,13 @@ mod tests {
 
     #[test]
     fn too_many_fat_entries() {
+        use std::io::Write;
+
         let cfb = make_cfb_with_inconsistent_difat_entries().unwrap();
 
-        CompoundFile::open(Cursor::new(cfb)).unwrap();
+        let mut cfb = CompoundFile::open(Cursor::new(cfb)).unwrap();
+        let mut f = cfb.create_stream("stream").unwrap();
+        f.write_all(&vec![0; 1024 * 1024]).unwrap();
     }
 }
 


### PR DESCRIPTION
I misdiagnosed the fix in #64. I was going off some guesswork because of difficult access to the client instance. Having spent more time debugging the actual issue is that an off-by-one error stores the `DIFAT_SECTOR` in the FAT at one beyond the end of the file. The actual location of the `DIFAT_SECTOR` in the example mentioned in #63 is 17871, the very last sector.

By stripping the `DIFAT_SECTOR` beyond the end, the builtin autofixing puts the `DIFAT_SECTOR` at the correct location.