### PR TITLE
Pad with free

### DIFF
--- a/src/internal/alloc.rs
+++ b/src/internal/alloc.rs
@@ -92,41 +92,41 @@ impl<F> Allocator<F> {
         }
         for &difat_sector in self.difat_sector_ids.iter() {
             let difat_sector_index = difat_sector as usize;
-            if difat_sector_index >= self.fat.len() {
+            let Some(sector) = self.fat.get_mut(difat_sector_index) else {
                 malformed!(
                     "FAT has {} entries, but DIFAT lists {} as a DIFAT sector",
                     self.fat.len(),
                     difat_sector
                 );
-            }
-            if self.fat[difat_sector_index] != consts::DIFAT_SECTOR {
+            };
+            if *sector != consts::DIFAT_SECTOR {
                 if validation.is_strict() {
                     malformed!(
                         "DIFAT sector {} is not marked as such in the FAT",
                         difat_sector
                     );
                 } else {
-                    self.fat[difat_sector_index] = consts::DIFAT_SECTOR;
+                    *sector = consts::DIFAT_SECTOR;
                 }
             }
         }
         for &fat_sector in self.difat.iter() {
             let fat_sector_index = fat_sector as usize;
-            if fat_sector_index >= self.fat.len() {
+            let Some(sector) = self.fat.get_mut(fat_sector_index) else {
                 malformed!(
                     "FAT has {} entries, but DIFAT lists {} as a FAT sector",
                     self.fat.len(),
                     fat_sector
                 );
-            }
-            if self.fat[fat_sector_index] != consts::FAT_SECTOR {
+            };
+            if *sector != consts::FAT_SECTOR {
                 if validation.is_strict() {
                     malformed!(
                         "FAT sector {} is not marked as such in the FAT",
                         fat_sector
                     );
                 } else {
-                    self.fat[fat_sector_index] = consts::FAT_SECTOR;
+                    *sector = consts::FAT_SECTOR;
                 }
             }
         }

--- a/src/internal/alloc.rs
+++ b/src/internal/alloc.rs
@@ -99,16 +99,13 @@ impl<F> Allocator<F> {
                     difat_sector
                 );
             };
-            if *sector != consts::DIFAT_SECTOR {
-                if validation.is_strict() {
-                    malformed!(
-                        "DIFAT sector {} is not marked as such in the FAT",
-                        difat_sector
-                    );
-                } else {
-                    *sector = consts::DIFAT_SECTOR;
-                }
+            if *sector != consts::DIFAT_SECTOR && validation.is_strict() {
+                malformed!(
+                    "DIFAT sector {} is not marked as such in the FAT",
+                    difat_sector
+                );
             }
+            *sector = consts::DIFAT_SECTOR;
         }
         for &fat_sector in self.difat.iter() {
             let fat_sector_index = fat_sector as usize;
@@ -119,16 +116,13 @@ impl<F> Allocator<F> {
                     fat_sector
                 );
             };
-            if *sector != consts::FAT_SECTOR {
-                if validation.is_strict() {
-                    malformed!(
-                        "FAT sector {} is not marked as such in the FAT",
-                        fat_sector
-                    );
-                } else {
-                    *sector = consts::FAT_SECTOR;
-                }
+            if *sector != consts::FAT_SECTOR && validation.is_strict() {
+                malformed!(
+                    "FAT sector {} is not marked as such in the FAT",
+                    fat_sector
+                );
             }
+            *sector = consts::FAT_SECTOR;
         }
         let mut pointees = FnvHashSet::default();
         for (from_sector, &to_sector) in self.fat.iter().enumerate() {

--- a/src/internal/consts.rs
+++ b/src/internal/consts.rs
@@ -33,22 +33,22 @@ pub const ROOT_STREAM_ID: u32 = 0;
 pub const MAX_REGULAR_STREAM_ID: u32 = 0xfffffffa;
 pub const NO_STREAM: u32 = 0xffffffff;
 
-pub(crate) fn prettify(sectors: &[u32]) -> Vec<Ty> {
+pub(crate) fn prettify(sectors: &[u32]) -> Vec<Type> {
     let mut fmt = Vec::new();
     for s in sectors.iter() {
         match *s {
-            END_OF_CHAIN => fmt.push(Ty::End),
-            FREE_SECTOR => fmt.push(Ty::Free),
-            DIFAT_SECTOR => fmt.push(Ty::Difat),
-            FAT_SECTOR => fmt.push(Ty::Fat),
+            END_OF_CHAIN => fmt.push(Type::End),
+            FREE_SECTOR => fmt.push(Type::Free),
+            DIFAT_SECTOR => fmt.push(Type::Difat),
+            FAT_SECTOR => fmt.push(Type::Fat),
             i => {
-                if let Some(Ty::Range(_, end)) = fmt.last_mut() {
+                if let Some(Type::Range(_, end)) = fmt.last_mut() {
                     if *end + 1 == i {
                         *end += 1;
                         continue;
                     }
                 }
-                fmt.push(Ty::Range(i, i));
+                fmt.push(Type::Range(i, i));
             }
         };
     }
@@ -56,7 +56,7 @@ pub(crate) fn prettify(sectors: &[u32]) -> Vec<Ty> {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-pub(crate) enum Ty {
+pub(crate) enum Type {
     Free,
     End,
     Fat,
@@ -64,15 +64,15 @@ pub(crate) enum Ty {
     Range(u32, u32),
 }
 
-impl std::fmt::Debug for Ty {
+impl std::fmt::Debug for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Ty::Range(start, end) if *start == *end => write!(f, "{start}"),
-            Ty::Range(start, end) => write!(f, "{start}-{end}"),
-            Ty::Free => f.write_str("FREE"),
-            Ty::End => f.write_str("EOC"),
-            Ty::Fat => f.write_str("FAT"),
-            Ty::Difat => f.write_str("DIFAT"),
+            Type::Range(start, end) if *start == *end => write!(f, "{start}"),
+            Type::Range(start, end) => write!(f, "{start}-{end}"),
+            Type::Free => f.write_str("FREE"),
+            Type::End => f.write_str("EOC"),
+            Type::Fat => f.write_str("FAT"),
+            Type::Difat => f.write_str("DIFAT"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,12 +500,15 @@ impl<F: Read + Seek> CompoundFile<F> {
         // case above, we can remove these even if it makes the number of FAT
         // entries less than the number of sectors in the file; the allocator
         // will implicitly treat these extra sectors as free.
-        while fat.last() == Some(&consts::FREE_SECTOR)
+        while fat.len() > sectors.num_sectors() as usize && fat.last() == Some(&consts::FREE_SECTOR)
             // strip DIFAT_SECTOR from the end
             || !validation.is_strict()
                 && fat.len() > sectors.num_sectors() as usize && fat.last() == Some(&consts::DIFAT_SECTOR)
         {
             fat.pop();
+        }
+        while fat.len() < sectors.num_sectors() as usize {
+            fat.push(consts::FREE_SECTOR);
         }
 
         let mut allocator =


### PR DESCRIPTION
I ran into errors of the form
```
'Malformed FAT (FAT has 14976 entries, but DIFAT lists 14976 as a DIFAT sector)'
```
and tracked it down to a `FREE_SECTOR` at the end of the file. When the `FREE_SECTOR` are stripped from the end of the FAT, and the DIFAT points to that sector, then the call to `fn validate` will not have a chance to try and fix the .cfb.
With this fix the files that had the error now succeed.

I may try and come up with a synthetic version of those files, but I'm making this PR without them for now. I also added some of the code I wrote to debug this.