### PR TITLE
perf: improve case-insensitive string compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,43 @@
 # rust-cfb
+
 [![Build Status](https://github.com/mdsteele/rust-cfb/actions/workflows/tests.yml/badge.svg)](https://github.com/mdsteele/rust-cfb/actions/workflows/tests.yml)
 [![Crates.io](https://img.shields.io/crates/v/cfb.svg)](https://crates.io/crates/cfb)
 [![Documentation](https://docs.rs/cfb/badge.svg)](https://docs.rs/cfb)
 
 A Rust library for reading/writing [Compound File Binary](
 https://en.wikipedia.org/wiki/Compound_File_Binary_Format) (structured storage)
-files.  See [MS-CFB](https://msdn.microsoft.com/en-us/library/dd942138.aspx)
+files. See [MS-CFB](https://msdn.microsoft.com/en-us/library/dd942138.aspx)
 for the format specification.
 
 ## License
 
 rust-cfb is made available under the
 [MIT License](http://spdx.org/licenses/MIT.html).
+
+## Development
+
+This project uses [Cargo](https://doc.rust-lang.org/cargo/) as its build system
+and package manager.
+
+### Tests
+
+```bash
+cargo test
+```
+
+### Benchmarks
+
+There is a benchmark suite using [Criterion.rs](https://github.com/bheisler/criterion.rs). To run the benchmarks:
+
+```bash
+cargo bench
+```
+
+For a clean run (reset Criterion stats), delete the Criterion output directory and re-run:
+
+```bash
+rm -rf target/criterion
+cargo bench
+```
+
+

--- a/src/internal/path.rs
+++ b/src/internal/path.rs
@@ -43,17 +43,38 @@ fn cfb_uppercase_char(c: char) -> char {
 /// order](https://en.wikipedia.org/wiki/Shortlex_order), rather than
 /// dictionary order).
 pub fn compare_names(name1: &str, name2: &str) -> Ordering {
-    match name1.encode_utf16().count().cmp(&name2.encode_utf16().count()) {
-        // This is actually not 100% correct -- the MS-CFB spec specifies a
-        // particular way of doing the uppercasing on individual UTF-16 code
-        // units, along with a list of weird exceptions and corner cases.  But
-        // hopefully this is good enough for 99+% of the time.
-        Ordering::Equal => {
-            let n1 = name1.chars().map(cfb_uppercase_char);
-            let n2 = name2.chars().map(cfb_uppercase_char);
-            n1.cmp(n2)
+    // This ASCII fast-path is important for performance.
+    // We saw a 10x speedup for many small streams when comparing pure ascii names.
+    // Make sure you run the write benchmark before and after changing this code
+    // to not introduce regressions.
+    if name1.is_ascii() && name2.is_ascii() {
+        match name1.len().cmp(&name2.len()) {
+            Ordering::Equal => {
+                for (left, right) in name1.bytes().zip(name2.bytes()) {
+                    let left = left.to_ascii_uppercase();
+                    let right = right.to_ascii_uppercase();
+                    match left.cmp(&right) {
+                        Ordering::Equal => {}
+                        other => return other,
+                    }
+                }
+                Ordering::Equal
+            }
+            other => other,
         }
-        other => other,
+    } else {
+        match name1.encode_utf16().count().cmp(&name2.encode_utf16().count()) {
+            // This is actually not 100% correct -- the MS-CFB spec specifies a
+            // particular way of doing the uppercasing on individual UTF-16 code
+            // units, along with a list of weird exceptions and corner cases.  But
+            // hopefully this is good enough for 99+% of the time.
+            Ordering::Equal => {
+                let n1 = name1.chars().map(cfb_uppercase_char);
+                let n2 = name2.chars().map(cfb_uppercase_char);
+                n1.cmp(n2)
+            }
+            other => other,
+        }
     }
 }
 


### PR DESCRIPTION
Did some performance testing and this was a serious bottleneck for files with large amounts of streams.

master:
```
write many smaller streams/total/default
                        time:   [75.344 ms 75.390 ms 75.472 ms]
                        thrpt:  [828.12 KiB/s 829.02 KiB/s 829.53 KiB/s]
```

this pull request:
```
write many smaller streams/total/default
                        time:   [9.8702 ms 9.9169 ms 9.9802 ms]
                        thrpt:  [6.1156 MiB/s 6.1547 MiB/s 6.1838 MiB/s]
                 change:
                        time:   [−86.927% −86.889% −86.837%] (p = 0.00 < 0.05)
                        thrpt:  [+659.70% +662.75% +664.96%]
                        Performance has improved.
```

I have even more improvements coming but wanted this merged first.