### PR TITLE
perf: optimize MiniFAT free sector management

### DIFF
--- a/src/internal/alloc.rs
+++ b/src/internal/alloc.rs
@@ -342,6 +342,9 @@ impl<F: Write + Seek> Allocator<F> {
 
     /// Deallocates the specified sector.
     fn free_sector(&mut self, sector_id: u32) -> io::Result<()> {
+        if self.fat.get(sector_id as usize) == Some(&consts::FREE_SECTOR) {
+            invalid_input!("sector {} freed twice", sector_id);
+        }
         self.set_fat(sector_id, consts::FREE_SECTOR)?;
         self.free_sectors.push(sector_id);
         // TODO: Truncate FAT if last FAT sector is now all free.


### PR DESCRIPTION
- same as #72 but for the MiniFAT
- Adds a worst case benchmark for MiniFAT write

benchmark result:

```
write MiniFAT max streams/total/default
                        time:   [51.553 ms 51.682 ms 51.865 ms]
                        thrpt:  [37.649 MiB/s 37.782 MiB/s 37.876 MiB/s]
                 change:
                        time:   [−67.689% −67.435% −67.222%] (p = 0.00 < 0.05)
                        thrpt:  [+205.08% +207.07% +209.49%]
                        Performance has improved.
```