### PR TITLE
feat: dynamic stream buffer

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -23,7 +23,7 @@ fn write_many_streams(
             let mut stream = match stream_buffer_size {
                 Some(buf_size) => {
                     let options =
-                        CreateStreamOptions::new().buffer_size(buf_size);
+                        CreateStreamOptions::new().max_buffer_size(buf_size);
                     test_comp
                         .create_stream_with_options(name, options)
                         .unwrap()
@@ -57,7 +57,7 @@ fn write_many_streams_disk(
             let mut stream = match stream_buffer_size {
                 Some(buf_size) => {
                     let options =
-                        CreateStreamOptions::new().buffer_size(buf_size);
+                        CreateStreamOptions::new().max_buffer_size(buf_size);
                     test_comp
                         .create_stream_with_options(name, options)
                         .unwrap()

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,18 +1,12 @@
-use cfb::{CompoundFile, CreateStreamOptions};
-use criterion::{
-    criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
-};
+use cfb::CompoundFile;
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use std::fs::OpenOptions;
 use std::hint::black_box;
 use std::io::Cursor;
 use std::io::Write;
 use tempfile::NamedTempFile;
 
-fn write_many_streams(
-    n: usize,
-    size: usize,
-    stream_buffer_size: Option<usize>,
-) -> Vec<u8> {
+fn write_many_streams(n: usize, size: usize) -> Vec<u8> {
     let mut buff = Vec::new();
     {
         let mut test_comp =
@@ -20,27 +14,14 @@ fn write_many_streams(
         let data = vec![0; size];
         for i in 0..n {
             let name = format!("test{i}");
-            let mut stream = match stream_buffer_size {
-                Some(buf_size) => {
-                    let options =
-                        CreateStreamOptions::new().max_buffer_size(buf_size);
-                    test_comp
-                        .create_stream_with_options(name, options)
-                        .unwrap()
-                }
-                None => test_comp.create_stream(name).unwrap(),
-            };
+            let mut stream = test_comp.create_stream(name).unwrap();
             stream.write_all(&data).unwrap();
         }
     }
     buff
 }
 
-fn write_many_streams_disk(
-    n: usize,
-    size: usize,
-    stream_buffer_size: Option<usize>,
-) {
+fn write_many_streams_disk(n: usize, size: usize) {
     let tmpfile = NamedTempFile::new().unwrap();
     {
         let mut test_comp = CompoundFile::create(
@@ -54,16 +35,7 @@ fn write_many_streams_disk(
         let data = vec![0; size];
         for i in 0..n {
             let name = format!("test{i}");
-            let mut stream = match stream_buffer_size {
-                Some(buf_size) => {
-                    let options =
-                        CreateStreamOptions::new().max_buffer_size(buf_size);
-                    test_comp
-                        .create_stream_with_options(name, options)
-                        .unwrap()
-                }
-                None => test_comp.create_stream(name).unwrap(),
-            };
+            let mut stream = test_comp.create_stream(name).unwrap();
             stream.write_all(&data).unwrap();
         }
     }
@@ -71,142 +43,47 @@ fn write_many_streams_disk(
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    // Buffer sizes to compare (in bytes). `None` means the default internal
-    // stream buffer size.
-    let buffer_sizes: &[(Option<usize>, &str)] = &[
-        (None, "default"),
-        (Some(8 * 1024), "buffer=8192"),
-        (Some(64 * 1024), "buffer=65536"),
-        (Some(256 * 1024), "buffer=262144"),
-        (Some(1024 * 1024), "buffer=1048576"),
+    let stream_benches = [
+        // (label, stream_size, stream_count)
+        ("n=1000,size=64B", 64usize, 1000usize),
+        ("n=100,size=4KiB-1 (MiniFAT)", 1024 * 4 - 1, 100usize),
+        ("n=100,size=4KiB (FAT)", 1024 * 4, 100usize),
+        ("n=50,size=1MiB", 1024 * 1024usize, 50usize),
+        ("n=1,size=256MiB", 256 * 1024 * 1024usize, 1usize),
     ];
 
-    // many small streams with throughput reporting
-    let mut small = c.benchmark_group("write many smaller streams");
-    let size = 64usize;
-    let n = 1000;
-    let total_bytes = (n * size) as u64;
-    small.sample_size(10);
-    small.throughput(Throughput::Bytes(total_bytes));
-
-    for (buf, label) in buffer_sizes {
-        small.bench_with_input(
-            BenchmarkId::new("total", *label),
-            &size,
-            |b, &s| {
-                b.iter(|| {
-                    let out = write_many_streams(
-                        black_box(n),
-                        black_box(s),
-                        buf.map(black_box),
-                    );
-                    black_box(out);
-                })
-            },
-        );
-    }
-    small.finish();
-
-    // streams just below the MiniFAT cutoff
-    let mut cutoff = c.benchmark_group("write MiniFAT max streams");
-    let size = (4 * 1024) - 1;
-    let n = 500;
-    let total_bytes = (n * size) as u64;
-    cutoff.sample_size(10);
-    cutoff.throughput(Throughput::Bytes(total_bytes));
-
-    for (buf, label) in buffer_sizes {
-        cutoff.bench_with_input(
-            BenchmarkId::new("total", *label),
-            &size,
-            |b, &s| {
-                b.iter(|| {
-                    let out = write_many_streams(
-                        black_box(n),
-                        black_box(s),
-                        buf.map(black_box),
-                    );
-                    black_box(out);
-                })
-            },
-        );
-    }
-    cutoff.finish();
-
-    // several medium streams with throughput reporting
-    let mut medium = c.benchmark_group("write several medium streams");
-    let size = 1024 * 1024usize;
-    let n = 50;
-    let total_bytes = (n * size) as u64;
-    medium.sample_size(10);
-    medium.throughput(Throughput::Bytes(total_bytes));
-
-    for (buf, label) in buffer_sizes {
-        medium.bench_with_input(
-            BenchmarkId::new("total", *label),
-            &size,
-            |b, &s| {
-                b.iter(|| {
-                    let out = write_many_streams(
-                        black_box(n),
-                        black_box(s),
-                        buf.map(black_box),
-                    );
-                    black_box(out);
-                })
-            },
-        );
-    }
-    medium.finish();
-
-    // single large stream with throughput reporting
-    let mut group = c.benchmark_group("write large stream");
-    let size = 256 * 1024 * 1024usize;
-    let n = 1;
-    group.sample_size(10);
-    group.throughput(Throughput::Bytes(size as u64));
-    for (buf, label) in buffer_sizes {
-        group.bench_with_input(
-            BenchmarkId::new("total", *label),
-            &size,
-            |b, &s| {
-                b.iter(|| {
-                    let out = write_many_streams(
-                        black_box(n),
-                        black_box(s),
-                        buf.map(black_box),
-                    );
-                    black_box(out);
-                })
-            },
-        );
+    let mut group = c.benchmark_group("streams_memory");
+    for (label, stream_size, stream_count) in stream_benches {
+        let total_bytes = (stream_count * stream_size) as u64;
+        group.sample_size(10);
+        group.throughput(Throughput::Bytes(total_bytes));
+        group.bench_function(label, |b| {
+            b.iter(|| {
+                let out = write_many_streams(
+                    black_box(stream_count),
+                    black_box(stream_size),
+                );
+                black_box(out);
+            })
+        });
     }
     group.finish();
 
-    // many small streams with throughput reporting (disk)
-    let mut small_disk =
-        c.benchmark_group("write many smaller streams (disk)");
-    let size = 64usize;
-    let n = 1000;
-    let total_bytes = (n * size) as u64;
-    small_disk.sample_size(10);
-    small_disk.throughput(Throughput::Bytes(total_bytes));
-    for (buf, label) in buffer_sizes {
-        small_disk.bench_with_input(
-            BenchmarkId::new("total", *label),
-            &size,
-            |b, &s| {
-                b.iter(|| {
-                    write_many_streams_disk(
-                        black_box(n),
-                        black_box(s),
-                        buf.map(black_box),
-                    );
-                })
-            },
-        );
+    let mut disk_group = c.benchmark_group("streams_disk");
+    for (label, stream_size, stream_count) in stream_benches {
+        let total_bytes = (stream_count * stream_size) as u64;
+        disk_group.sample_size(10);
+        disk_group.throughput(Throughput::Bytes(total_bytes));
+        disk_group.bench_function(label, |b| {
+            b.iter(|| {
+                write_many_streams_disk(
+                    black_box(stream_count),
+                    black_box(stream_size),
+                );
+            })
+        });
     }
-    small_disk.finish();
+    disk_group.finish();
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -57,6 +57,7 @@ fn read_many_streams(buff: &[u8], n: usize) {
 fn criterion_benchmark(c: &mut Criterion) {
     let stream_benches = [
         // (label, stream_size, stream_count)
+        ("n=10000,size=0B", 0, 10000usize),
         ("n=1000,size=64B", 64usize, 1000usize),
         ("n=100,size=4KiB-1 (MiniFAT)", 1024 * 4 - 1, 100usize),
         ("n=100,size=4KiB (FAT)", 1024 * 4, 100usize),
@@ -68,7 +69,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     for (label, stream_size, stream_count) in stream_benches {
         let total_bytes = (stream_count * stream_size) as u64;
         group.sample_size(10);
-        group.throughput(Throughput::Bytes(total_bytes));
+        if total_bytes > 0 {
+            group.throughput(Throughput::Bytes(total_bytes));
+        }
         group.bench_function(label, |b| {
             b.iter(|| {
                 let out = write_many_streams(
@@ -85,7 +88,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     for (label, stream_size, stream_count) in stream_benches {
         let total_bytes = (stream_count * stream_size) as u64;
         disk_group.sample_size(10);
-        disk_group.throughput(Throughput::Bytes(total_bytes));
+        if total_bytes > 0 {
+            disk_group.throughput(Throughput::Bytes(total_bytes));
+        }
         disk_group.bench_function(label, |b| {
             b.iter(|| {
                 write_many_streams_disk(
@@ -102,7 +107,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         let total_bytes = (stream_count * stream_size) as u64;
         let buff = write_many_streams(stream_count, stream_size);
         read_group.sample_size(10);
-        read_group.throughput(Throughput::Bytes(total_bytes));
+        if total_bytes > 0 {
+            read_group.throughput(Throughput::Bytes(total_bytes));
+        }
         read_group.bench_function(label, |b| {
             b.iter(|| {
                 read_many_streams(black_box(&buff), black_box(stream_count));

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -15,6 +15,7 @@ mod objtype;
 pub mod path;
 mod sector;
 mod stream;
+mod stream_buffer;
 mod timestamp;
 mod validate;
 mod version;

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -32,6 +32,7 @@ pub use self::minichain::MiniChain;
 pub use self::objtype::ObjType;
 pub use self::sector::{Sector, SectorInit, Sectors};
 pub use self::stream::Stream;
+pub(crate) use self::stream_buffer::DEFAULT_STREAM_MAX_BUFFER_SIZE;
 pub use self::timestamp::Timestamp;
 pub use self::validate::Validation;
 pub use self::version::Version;

--- a/src/internal/stream.rs
+++ b/src/internal/stream.rs
@@ -107,10 +107,11 @@ impl<F: Read + Seek> BufRead for Stream<F> {
         {
             self.flush_changes()?;
             self.buf_offset_from_start += self.buffer.cursor() as u64;
+            let remaining = self.total_len - self.buf_offset_from_start;
             let stream_id = self.stream_id;
             let offset = self.buf_offset_from_start;
             let minialloc = self.minialloc()?;
-            self.buffer.refill_with(|buf| {
+            self.buffer.refill_with(remaining, |buf| {
                 read_data_from_stream(
                     &mut minialloc.write().unwrap(),
                     stream_id,

--- a/src/internal/stream_buffer.rs
+++ b/src/internal/stream_buffer.rs
@@ -1,6 +1,8 @@
 const STREAM_BUFFER_MIN: usize = 1024;
 const STREAM_BUFFER_GROWTH_FACTOR: usize = 4;
 
+pub(crate) const DEFAULT_STREAM_MAX_BUFFER_SIZE: usize = 1024 * 1024;
+
 use std::io::{self, Write};
 
 /// A buffer for stream data that grows up to a configurable maximum.
@@ -16,7 +18,7 @@ pub(crate) struct StreamBuffer {
 
 impl Default for StreamBuffer {
     fn default() -> Self {
-        StreamBuffer::new(1024 * 1024)
+        StreamBuffer::new(DEFAULT_STREAM_MAX_BUFFER_SIZE)
     }
 }
 

--- a/src/internal/stream_buffer.rs
+++ b/src/internal/stream_buffer.rs
@@ -1,0 +1,251 @@
+const STREAM_BUFFER_MIN: usize = 1024;
+const STREAM_BUFFER_GROWTH_FACTOR: usize = 4;
+
+use std::io::{self, Write};
+
+/// A buffer for stream data that grows up to a configurable maximum.
+///
+/// The buffer starts at a minimum size, grows by a fixed factor, and never
+/// exceeds the configured max.
+pub(crate) struct StreamBuffer {
+    data: Vec<u8>,
+    pos: usize,
+    cap: usize,
+    max_size: usize,
+}
+
+impl Default for StreamBuffer {
+    fn default() -> Self {
+        StreamBuffer::new(1024 * 1024)
+    }
+}
+
+impl StreamBuffer {
+    pub(crate) fn new(max_buffer_size: usize) -> StreamBuffer {
+        StreamBuffer {
+            data: vec![0; STREAM_BUFFER_MIN],
+            pos: 0,
+            cap: 0,
+            max_size: max_buffer_size.max(STREAM_BUFFER_MIN),
+        }
+    }
+
+    pub(crate) fn cursor(&self) -> usize {
+        self.pos
+    }
+
+    pub(crate) fn filled_len(&self) -> usize {
+        self.cap
+    }
+
+    pub(crate) fn has_remaining(&self) -> bool {
+        self.pos < self.cap
+    }
+
+    pub(crate) fn remaining_slice(&self) -> &[u8] {
+        &self.data[self.pos..self.cap]
+    }
+
+    pub(crate) fn filled_slice(&self) -> &[u8] {
+        &self.data[..self.cap]
+    }
+
+    pub(crate) fn refill_with<F>(&mut self, fill: F) -> io::Result<()>
+    where
+        F: FnOnce(&mut [u8]) -> io::Result<usize>,
+    {
+        self.pos = 0;
+        let cap = fill(&mut self.data)?;
+        self.set_cap(cap);
+        Ok(())
+    }
+
+    /// Writes bytes into the buffer at the current cursor.
+    /// Returns the number of bytes written, or None if the buffer cannot grow.
+    pub(crate) fn write_bytes(&mut self, input: &[u8]) -> Option<usize> {
+        debug_assert!(self.pos <= self.data.len());
+        if self.pos >= self.data.len() && !self.grow() {
+            return None;
+        }
+        let written = (&mut self.data[self.pos..]).write(input).unwrap_or(0);
+        self.pos += written;
+        debug_assert!(self.pos <= self.data.len());
+        if self.cap < self.pos {
+            self.cap = self.pos;
+        }
+        Some(written)
+    }
+
+    /// Moves the cursor to an absolute position within the buffer.
+    pub(crate) fn seek(&mut self, pos: usize) {
+        debug_assert!(pos <= self.data.len());
+        self.pos = pos;
+        if self.cap < self.pos {
+            self.cap = self.pos;
+        }
+    }
+
+    fn set_cap(&mut self, cap: usize) {
+        debug_assert!(cap <= self.data.len());
+        self.cap = cap;
+        if self.pos > self.cap {
+            self.pos = self.cap;
+        }
+    }
+
+    /// Clears the filled region and resets the cursor to 0.
+    pub(crate) fn clear(&mut self) {
+        self.pos = 0;
+        self.cap = 0;
+    }
+
+    /// Consumes bytes from the filled region, asserting it stays in-bounds.
+    pub(crate) fn consume(&mut self, amt: usize) {
+        debug_assert!(self.pos + amt <= self.cap);
+        self.pos += amt;
+    }
+
+    /// Attempts to grow the buffer, returning false if at max size.
+    pub(crate) fn grow(&mut self) -> bool {
+        if self.data.len() >= self.max_size {
+            return false;
+        }
+        let new_len =
+            (self.data.len() * STREAM_BUFFER_GROWTH_FACTOR).min(self.max_size);
+        self.data.resize(new_len, 0);
+        true
+    }
+
+    #[cfg(test)]
+    fn data_len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stream_buffer_advance() {
+        let mut buffer = StreamBuffer::default();
+        buffer.refill_with(|_| Ok(8)).unwrap();
+        buffer.consume(3);
+        assert_eq!(buffer.cursor(), 3);
+        buffer.consume(5);
+        assert_eq!(buffer.cursor(), 8);
+    }
+
+    #[test]
+    #[should_panic]
+    fn stream_buffer_consume_panics_past_cap() {
+        let mut buffer = StreamBuffer::default();
+        buffer.refill_with(|_| Ok(4)).unwrap();
+        buffer.consume(5);
+    }
+
+    #[test]
+    fn stream_buffer_grows_until_max() {
+        const STREAM_BUFFER_MAX: usize = 1024 * 1024;
+        let mut buffer = StreamBuffer::new(STREAM_BUFFER_MAX);
+        let mut expected = STREAM_BUFFER_MIN;
+        while expected < STREAM_BUFFER_MAX {
+            assert!(buffer.grow());
+            expected = (expected * STREAM_BUFFER_GROWTH_FACTOR)
+                .min(STREAM_BUFFER_MAX);
+            assert_eq!(buffer.data_len(), expected);
+        }
+        assert!(!buffer.grow());
+        assert_eq!(buffer.data_len(), STREAM_BUFFER_MAX);
+    }
+
+    #[test]
+    fn stream_buffer_respects_custom_max() {
+        const CUSTOM_MAX: usize = 1024 * 4;
+        let mut buffer = StreamBuffer::new(CUSTOM_MAX);
+        assert!(buffer.grow());
+        assert_eq!(buffer.data_len(), CUSTOM_MAX);
+        assert!(!buffer.grow());
+    }
+
+    #[test]
+    fn stream_buffer_refill_resets_cursor() {
+        let mut buffer = StreamBuffer::default();
+        buffer.seek(5);
+        buffer.refill_with(|_| Ok(3)).unwrap();
+        assert_eq!(buffer.cursor(), 0);
+        assert_eq!(buffer.filled_len(), 3);
+    }
+
+    #[test]
+    fn stream_buffer_seek_expands_cap() {
+        let mut buffer = StreamBuffer::default();
+        buffer.seek(4);
+        assert_eq!(buffer.cursor(), 4);
+        assert_eq!(buffer.filled_len(), 4);
+    }
+
+    #[test]
+    fn stream_buffer_seek_allows_len_boundary() {
+        let mut buffer = StreamBuffer::default();
+        let len = STREAM_BUFFER_MIN;
+        buffer.seek(len);
+        assert_eq!(buffer.cursor(), len);
+        assert_eq!(buffer.filled_len(), len);
+    }
+
+    #[test]
+    fn stream_buffer_set_cap_allows_len_boundary() {
+        let mut buffer = StreamBuffer::default();
+        let len = STREAM_BUFFER_MIN;
+        buffer.refill_with(|_| Ok(len)).unwrap();
+        assert_eq!(buffer.filled_len(), len);
+    }
+
+    #[test]
+    fn stream_buffer_grow_preserves_pos_and_cap() {
+        let mut buffer = StreamBuffer::default();
+        buffer.refill_with(|_| Ok(12)).unwrap();
+        buffer.seek(8);
+        assert!(buffer.grow());
+        assert_eq!(buffer.cursor(), 8);
+        assert_eq!(buffer.filled_len(), 12);
+    }
+
+    #[test]
+    fn stream_buffer_clamps_max_below_min() {
+        let mut buffer = StreamBuffer::new(1);
+        assert_eq!(buffer.data_len(), STREAM_BUFFER_MIN);
+        assert!(!buffer.grow());
+    }
+
+    #[test]
+    fn stream_buffer_refill_error_keeps_cap() {
+        let mut buffer = StreamBuffer::default();
+        buffer.refill_with(|_| Ok(4)).unwrap();
+        buffer.seek(2);
+        let result = buffer.refill_with(|_| Err(io::Error::other("fail")));
+        assert!(result.is_err());
+        assert_eq!(buffer.cursor(), 0);
+        assert_eq!(buffer.filled_len(), 4);
+    }
+
+    #[test]
+    fn stream_buffer_write_bytes_returns_none_when_full() {
+        let mut buffer = StreamBuffer::new(STREAM_BUFFER_MIN);
+        buffer.seek(STREAM_BUFFER_MIN);
+        assert!(buffer.write_bytes(&[1]).is_none());
+        assert_eq!(buffer.cursor(), STREAM_BUFFER_MIN);
+        assert_eq!(buffer.filled_len(), STREAM_BUFFER_MIN);
+    }
+
+    #[test]
+    fn stream_buffer_remaining_slice_matches_advance() {
+        let mut buffer = StreamBuffer::default();
+        buffer.refill_with(|_| Ok(6)).unwrap();
+        buffer.consume(2);
+        assert_eq!(buffer.remaining_slice().len(), 4);
+        buffer.consume(4);
+        assert!(buffer.remaining_slice().is_empty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ use fnv::FnvHashSet;
 use uuid::Uuid;
 
 use crate::internal::consts;
+use crate::internal::DEFAULT_STREAM_MAX_BUFFER_SIZE;
 use crate::internal::{
     Allocator, DirEntry, Directory, EntriesOrder, Header, MiniAllocator,
     ObjType, SectorInit, Sectors, Timestamp, Validation,
@@ -64,8 +65,6 @@ pub use crate::internal::{Entries, Entry, Stream, Version};
 
 #[macro_use]
 mod internal;
-
-const DEFAULT_STREAM_MAX_BUFFER_SIZE: usize = 1024 * 1024; // 1 MiB
 
 //===========================================================================//
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,17 +70,12 @@ mod internal;
 
 /// Opens an existing compound file at the given path in read-only mode.
 pub fn open<P: AsRef<Path>>(path: P) -> io::Result<CompoundFile<fs::File>> {
-    CompoundFile::open(fs::File::open(path)?)
+    OpenOptions::new().open(path)
 }
 
 /// Opens an existing compound file at the given path in read-write mode.
 pub fn open_rw<P: AsRef<Path>>(path: P) -> io::Result<CompoundFile<fs::File>> {
-    open_rw_with_path(path.as_ref())
-}
-
-fn open_rw_with_path(path: &Path) -> io::Result<CompoundFile<fs::File>> {
-    let file = fs::OpenOptions::new().read(true).write(true).open(path)?;
-    CompoundFile::open(file)
+    OpenOptions::new().open_rw(path)
 }
 
 /// Creates a new compound file with no contents at the given path.
@@ -88,34 +83,24 @@ fn open_rw_with_path(path: &Path) -> io::Result<CompoundFile<fs::File>> {
 /// The returned `CompoundFile` object will be both readable and writable.  If
 /// a file already exists at the given path, this will overwrite it.
 pub fn create<P: AsRef<Path>>(path: P) -> io::Result<CompoundFile<fs::File>> {
-    create_with_path(path.as_ref())
-}
-
-fn create_with_path(path: &Path) -> io::Result<CompoundFile<fs::File>> {
-    let file = fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path)?;
-    CompoundFile::create(file)
+    OpenOptions::new().create(path)
 }
 
 //===========================================================================//
 
-/// Options for creating a stream within a compound file.
-pub struct CreateStreamOptions {
+/// Options for opening or creating a compound file.
+pub struct OpenOptions {
     pub(crate) max_buffer_size: usize,
-    pub(crate) overwrite: bool,
+    pub(crate) validation: Validation,
 }
 
-impl CreateStreamOptions {
-    /// Creates a new `CreateStreamOptions` with default settings.
+impl OpenOptions {
+    /// Creates a new `OpenOptions` with default settings.
     pub fn new() -> Self {
-        CreateStreamOptions::default()
+        OpenOptions::default()
     }
 
-    /// Sets the maximum size of the stream's internal buffer.
+    /// Sets the maximum size of a stream's internal buffer.
     ///
     /// The buffer grows dynamically up to this limit. Larger limits can improve
     /// throughput for large streams, while smaller limits reduce peak memory
@@ -125,55 +110,77 @@ impl CreateStreamOptions {
         self
     }
 
-    /// Sets whether to overwrite an existing stream at the given path when
-    /// creating the stream.
-    ///
-    /// If `overwrite` is set to `true`, and a stream already exists at the
-    /// given path, the existing stream will be truncated to zero length.
-    /// If `overwrite` is set to `false`, and a stream already exists at the
-    /// given path, an error will be returned.
-    pub fn overwrite(mut self, overwrite: bool) -> Self {
-        self.overwrite = overwrite;
+    /// Any violation of the CFB spec will be treated as an error when parsing.
+    pub fn strict(mut self) -> Self {
+        self.validation = Validation::Strict;
         self
+    }
+
+    /// Opens an existing compound file at the given path in read-only mode.
+    pub fn open<P: AsRef<Path>>(
+        self,
+        path: P,
+    ) -> io::Result<CompoundFile<fs::File>> {
+        self.open_with(fs::File::open(path)?)
+    }
+
+    /// Opens an existing compound file at the given path in read-write mode.
+    pub fn open_rw<P: AsRef<Path>>(
+        self,
+        path: P,
+    ) -> io::Result<CompoundFile<fs::File>> {
+        let file = fs::OpenOptions::new().read(true).write(true).open(path)?;
+        self.open_with(file)
+    }
+
+    /// Creates a new compound file with no contents at the given path.
+    ///
+    /// The returned `CompoundFile` object will be both readable and writable.
+    /// If a file already exists at the given path, this will overwrite it.
+    pub fn create<P: AsRef<Path>>(
+        self,
+        path: P,
+    ) -> io::Result<CompoundFile<fs::File>> {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        self.create_with(file)
+    }
+
+    /// Opens an existing compound file using the underlying reader.
+    pub fn open_with<F: Read + Seek>(
+        self,
+        inner: F,
+    ) -> io::Result<CompoundFile<F>> {
+        CompoundFile::open_internal(
+            inner,
+            self.validation,
+            self.max_buffer_size,
+        )
+    }
+
+    /// Creates a new compound file with no contents using the underlying writer.
+    pub fn create_with<F: Read + Write + Seek>(
+        self,
+        inner: F,
+    ) -> io::Result<CompoundFile<F>> {
+        CompoundFile::create_with_version_and_options(
+            Version::V4,
+            inner,
+            self.max_buffer_size,
+        )
     }
 }
 
-impl Default for CreateStreamOptions {
+impl Default for OpenOptions {
     fn default() -> Self {
-        CreateStreamOptions {
+        OpenOptions {
             max_buffer_size: DEFAULT_STREAM_MAX_BUFFER_SIZE,
-            overwrite: false,
+            validation: Validation::Permissive,
         }
-    }
-}
-
-//===========================================================================//
-
-/// Options for opening a stream within a compound file.
-pub struct OpenStreamOptions {
-    pub(crate) max_buffer_size: usize,
-}
-
-impl OpenStreamOptions {
-    /// Creates a new `StreamOptions` with default settings.
-    pub fn new() -> Self {
-        OpenStreamOptions::default()
-    }
-
-    /// Sets the maximum size of the stream's internal buffer.
-    ///
-    /// The buffer grows dynamically up to this limit. Larger limits can improve
-    /// throughput for large streams, while smaller limits reduce peak memory
-    /// usage. Values below the internal minimum are clamped up to that minimum.
-    pub fn max_buffer_size(mut self, size: usize) -> Self {
-        self.max_buffer_size = size;
-        self
-    }
-}
-
-impl Default for OpenStreamOptions {
-    fn default() -> Self {
-        OpenStreamOptions { max_buffer_size: DEFAULT_STREAM_MAX_BUFFER_SIZE }
     }
 }
 
@@ -184,6 +191,7 @@ impl Default for OpenStreamOptions {
 /// [`Cursor`](https://doc.rust-lang.org/std/io/struct.Cursor.html)).
 pub struct CompoundFile<F> {
     minialloc: Arc<RwLock<MiniAllocator<F>>>,
+    max_buffer_size: usize,
 }
 
 impl<F> CompoundFile<F> {
@@ -384,31 +392,10 @@ impl<F: Seek> CompoundFile<F> {
         &mut self,
         path: P,
     ) -> io::Result<Stream<F>> {
-        self.open_stream_with_path(
-            path.as_ref(),
-            DEFAULT_STREAM_MAX_BUFFER_SIZE,
-        )
+        self.open_stream_with_path(path.as_ref())
     }
 
-    /// Opens an existing stream in the compound file for reading and/or
-    /// writing (depending on what the underlying file supports), with a specified buffer size.
-    ///
-    /// The buffer size determines how much data is read/written at a time when
-    /// accessing the stream. A larger buffer size can improve performance for
-    /// large streams, while a smaller buffer size can reduce memory usage.
-    pub fn open_stream_with_options<P: AsRef<Path>>(
-        &mut self,
-        path: P,
-        options: OpenStreamOptions,
-    ) -> io::Result<Stream<F>> {
-        self.open_stream_with_path(path.as_ref(), options.max_buffer_size)
-    }
-
-    fn open_stream_with_path(
-        &mut self,
-        path: &Path,
-        buffer_size: usize,
-    ) -> io::Result<Stream<F>> {
+    fn open_stream_with_path(&mut self, path: &Path) -> io::Result<Stream<F>> {
         let names = internal::path::name_chain_from_path(path)?;
         let path = internal::path::path_from_name_chain(&names);
         let stream_id = match self.stream_id_for_name_chain(&names) {
@@ -418,7 +405,7 @@ impl<F: Seek> CompoundFile<F> {
         if self.minialloc().dir_entry(stream_id).obj_type != ObjType::Stream {
             invalid_input!("Not a stream: {:?}", path);
         }
-        Ok(Stream::new(&self.minialloc, stream_id, buffer_size))
+        Ok(Stream::new(&self.minialloc, stream_id, self.max_buffer_size))
     }
 }
 
@@ -427,21 +414,22 @@ impl<F: Read + Seek> CompoundFile<F> {
     /// underlying reader also supports the `Write` trait, then the
     /// `CompoundFile` object will be writable as well.
     pub fn open(inner: F) -> io::Result<CompoundFile<F>> {
-        CompoundFile::open_internal(inner, Validation::Permissive)
+        OpenOptions::new().open_with(inner)
     }
 
     /// Like `open()`, but is stricter when parsing and will return an error if
     /// the file violates the CFB spec in any way (which many CFB files in the
     /// wild do).  This is mainly useful for validating a CFB file or
-    /// implemention (such as this crate itself) to help ensure compatibility
+    /// implementation (such as this crate itself) to help ensure compatibility
     /// with other readers.
     pub fn open_strict(inner: F) -> io::Result<CompoundFile<F>> {
-        CompoundFile::open_internal(inner, Validation::Strict)
+        OpenOptions::new().strict().open_with(inner)
     }
 
     fn open_internal(
         mut inner: F,
         validation: Validation,
+        max_buffer_size: usize,
     ) -> io::Result<CompoundFile<F>> {
         let inner_len = inner.seek(SeekFrom::End(0))?;
         if inner_len < consts::HEADER_LEN as u64 {
@@ -707,7 +695,10 @@ impl<F: Read + Seek> CompoundFile<F> {
             validation,
         )?;
 
-        Ok(CompoundFile { minialloc: Arc::new(RwLock::new(minialloc)) })
+        Ok(CompoundFile {
+            minialloc: Arc::new(RwLock::new(minialloc)),
+            max_buffer_size,
+        })
     }
 }
 
@@ -715,14 +706,26 @@ impl<F: Read + Write + Seek> CompoundFile<F> {
     /// Creates a new compound file with no contents, using the underlying
     /// reader/writer.  The reader/writer should be initially empty.
     pub fn create(inner: F) -> io::Result<CompoundFile<F>> {
-        CompoundFile::create_with_version(Version::V4, inner)
+        OpenOptions::new().create_with(inner)
     }
 
     /// Creates a new compound file of the given version with no contents,
     /// using the underlying writer.  The writer should be initially empty.
     pub fn create_with_version(
         version: Version,
+        inner: F,
+    ) -> io::Result<CompoundFile<F>> {
+        CompoundFile::create_with_version_and_options(
+            version,
+            inner,
+            DEFAULT_STREAM_MAX_BUFFER_SIZE,
+        )
+    }
+
+    fn create_with_version_and_options(
+        version: Version,
         mut inner: F,
+        max_buffer_size: usize,
     ) -> io::Result<CompoundFile<F>> {
         let mut header = Header {
             version,
@@ -785,7 +788,10 @@ impl<F: Read + Write + Seek> CompoundFile<F> {
             consts::END_OF_CHAIN,
             Validation::Strict,
         )?;
-        Ok(CompoundFile { minialloc: Arc::new(RwLock::new(minialloc)) })
+        Ok(CompoundFile {
+            minialloc: Arc::new(RwLock::new(minialloc)),
+            max_buffer_size,
+        })
     }
 
     /// Creates a new, empty storage object (i.e. "directory") at the provided
@@ -956,11 +962,7 @@ impl<F: Read + Write + Seek> CompoundFile<F> {
         &mut self,
         path: P,
     ) -> io::Result<Stream<F>> {
-        self.create_stream_with_path_and_max_buffer_size(
-            path.as_ref(),
-            true,
-            DEFAULT_STREAM_MAX_BUFFER_SIZE,
-        )
+        self.create_stream_with_path(path.as_ref(), true)
     }
 
     /// Creates and returns a new, empty stream object at the provided path.
@@ -970,35 +972,13 @@ impl<F: Read + Write + Seek> CompoundFile<F> {
         &mut self,
         path: P,
     ) -> io::Result<Stream<F>> {
-        self.create_stream_with_path_and_max_buffer_size(
-            path.as_ref(),
-            false,
-            DEFAULT_STREAM_MAX_BUFFER_SIZE,
-        )
+        self.create_stream_with_path(path.as_ref(), false)
     }
 
-    /// Creates and returns a new, empty stream object at the provided path,
-    /// using a custom per-stream buffer size.
-    ///
-    /// This is equivalent to `create_stream()`, except the returned `Stream`
-    /// uses `buffer_size` bytes for its internal read/write buffer.
-    pub fn create_stream_with_options<P: AsRef<Path>>(
-        &mut self,
-        path: P,
-        options: CreateStreamOptions,
-    ) -> io::Result<Stream<F>> {
-        self.create_stream_with_path_and_max_buffer_size(
-            path.as_ref(),
-            options.overwrite,
-            options.max_buffer_size,
-        )
-    }
-
-    fn create_stream_with_path_and_max_buffer_size(
+    fn create_stream_with_path(
         &mut self,
         path: &Path,
         overwrite: bool,
-        max_buffer_size: usize,
     ) -> io::Result<Stream<F>> {
         let mut names = internal::path::name_chain_from_path(path)?;
         if let Some(stream_id) = self.stream_id_for_name_chain(&names) {
@@ -1017,8 +997,11 @@ impl<F: Read + Write + Seek> CompoundFile<F> {
                     internal::path::path_from_name_chain(&names)
                 );
             } else {
-                let mut stream =
-                    Stream::new(&self.minialloc, stream_id, max_buffer_size);
+                let mut stream = Stream::new(
+                    &self.minialloc,
+                    stream_id,
+                    self.max_buffer_size,
+                );
                 stream.set_len(0)?;
                 return Ok(stream);
             }
@@ -1036,7 +1019,7 @@ impl<F: Read + Write + Seek> CompoundFile<F> {
             name,
             ObjType::Stream,
         )?;
-        Ok(Stream::new(&self.minialloc, new_stream_id, max_buffer_size))
+        Ok(Stream::new(&self.minialloc, new_stream_id, self.max_buffer_size))
     }
 
     /// Removes the stream object at the provided path.


### PR DESCRIPTION
This pull request introduces a new dynamically growing buffer implementation for streams, replacing the previous fixed-size buffer approach.

This introduces a breaking change as the options on the `Stream` have been moved to the `CompundFile`. Also you now configuring `max_buffer_size` instead of `buffer_size` with a default of 1 MiB.

I ran the original benchmark and with buffer size ignored there were only improvements, no regressions. So I removed the specific benchmarks per buffer size.