### PR TITLE
Allow accessing raw created/modified FILETIME

### DIFF
--- a/src/internal/entry.rs
+++ b/src/internal/entry.rs
@@ -89,10 +89,22 @@ impl Entry {
         self.creation_time.to_system_time()
     }
 
+    /// Returns the raw FILETIME value of [`created`], as it is stored in the
+    /// file.
+    pub fn created_raw(&self) -> u64 {
+        self.creation_time.raw_value()
+    }
+
     /// Returns the time when the object that this entry represents was last
     /// modified.
     pub fn modified(&self) -> SystemTime {
         self.modified_time.to_system_time()
+    }
+
+    /// Returns the raw FILETIME value of [`modified`], as it is stored in the
+    /// file.
+    pub fn modified_raw(&self) -> u64 {
+        self.modified_time.raw_value()
     }
 }
 

--- a/src/internal/timestamp.rs
+++ b/src/internal/timestamp.rs
@@ -36,6 +36,11 @@ impl Timestamp {
         system_time_from_timestamp(self.0)
     }
 
+    /// Returns the raw FILETIME value.
+    pub fn raw_value(self) -> u64 {
+        self.0
+    }
+
     pub fn read_from<R: Read>(reader: &mut R) -> io::Result<Timestamp> {
         Ok(Timestamp(reader.read_le_u64()?))
     }


### PR DESCRIPTION
I'm currently working on a crate verifying authenticode signatures for MSI, and using the CFB crate to parse the MSI files to achieve this.

To verify an MSI signature, it is necessary to access the raw created/modified values, as they are part of the authenticode hash[^0]. While it's technically possible to get the FILETIME back from the SystemTime, it's a lossy operation (a FILETIME that doesn't fit in a SystemTime converts it to SystemTime::UNIX_TIME). It'd be nicer to just have access to the raw value so we can guarantee we're hashing the correct value.

This MR adds two new methods to `Entry` to access the raw FILETIME values.

[^0]: http://github.com/ralphje/signify/blob/master/signify/authenticode/signed_file/msi.py#L193-L194