### PR TITLE
fix: refuse to create entries inside a stream

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,3 +23,9 @@ name = "fuzz_total"
 path = "fuzz_targets/fuzz_total.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_write"
+path = "fuzz_targets/fuzz_write.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_write.rs
+++ b/fuzz/fuzz_targets/fuzz_write.rs
@@ -1,0 +1,94 @@
+#![no_main]
+//! Drives the write side from fuzz input: a sequence of stream and storage
+//! creations, writes and removals with names and sizes taken from the
+//! bytes.  Afterwards the file must reopen under strict validation, every
+//! stream the model still expects must be found with the right content,
+//! and nothing else may be there.
+use cfb::CompoundFile;
+use libfuzzer_sys::fuzz_target;
+use std::collections::HashMap;
+use std::io::{Cursor, Read, Write};
+
+fuzz_target!(|data: &[u8]| {
+    let mut comp = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    // uppercased path -> Some(content) for streams, None for storages
+    // (names are case-insensitive, so `/s1` and `/S1` are one entry)
+    let mut model: HashMap<String, Option<Vec<u8>>> = HashMap::new();
+    let storages = ["/", "/A", "/B", "/A/C"];
+    let mut bytes = data.iter().copied();
+    while let (Some(op), Some(n1), Some(n2)) = (bytes.next(), bytes.next(), bytes.next()) {
+        let parent = storages[(n1 % 4) as usize];
+        // Names: a small alphabet with case variants, so that the same name
+        // in different cases and near-duplicates come up often.
+        let name = match n2 % 6 {
+            0 => format!("s{}", n1 / 4),
+            1 => format!("S{}", n1 / 4),
+            2 => format!("item{}", n1),
+            3 => format!("ITEM{}", n1),
+            4 => format!("{}", char::from(b'a' + n1 % 26)),
+            _ => format!("x{}y{}", n1 % 7, n2 % 5),
+        };
+        let path = if parent == "/" { format!("/{name}") } else { format!("{parent}/{name}") };
+        let key = path.to_uppercase();
+        match op % 5 {
+            0 | 1 | 2 => {
+                // Storages must exist first; skip creating under a missing one.
+                // The parent must exist and be a storage (a stream of that
+                // name, in any case, is not one).
+                if parent != "/" && model.get(&parent.to_uppercase()) != Some(&None) {
+                    continue;
+                }
+                if model.get(&key).map(|e| e.is_none()).unwrap_or(false) {
+                    continue; // a storage of that name exists
+                }
+                let len = (op as usize) * 700 + n2 as usize * 3; // 0..~2100 + up to 765
+                let len = if n1 % 5 == 0 { len * 4 } else { len }; // sometimes past the mini cutoff
+                let content: Vec<u8> = (0..len).map(|i| (i as u8) ^ n1).collect();
+                let mut stream = comp.create_stream(&path).unwrap();
+                stream.write_all(&content).unwrap();
+                drop(stream);
+                model.insert(key, Some(content));
+            }
+            3 => {
+                if let Some(Some(_)) = model.get(&key) {
+                    comp.remove_stream(&path).unwrap();
+                    model.remove(&key);
+                }
+            }
+            _ => {
+                // Create one of the fixed storages if missing.
+                let storage = storages[1 + (n2 % 3) as usize];
+                let parent_ok = storage == "/A" || storage == "/B" || model.get("/A") == Some(&None);
+                if parent_ok && !model.contains_key(&storage.to_uppercase()) {
+                    comp.create_storage(storage).unwrap();
+                    model.insert(storage.to_uppercase(), None);
+                }
+            }
+        }
+    }
+    comp.flush().unwrap();
+    let bytes = comp.into_inner().into_inner();
+    let mut comp = CompoundFile::open_strict(Cursor::new(bytes)).expect("strict reopen");
+    let entries: Vec<(String, bool)> = comp
+        .walk()
+        .map(|e| (e.path().to_str().unwrap().to_string(), e.is_stream()))
+        .collect();
+    let mut found = 0;
+    for (path, is_stream) in entries {
+        if path == "/" {
+            continue;
+        }
+        found += 1;
+        match model.get(&path.to_uppercase()) {
+            Some(Some(content)) => {
+                assert!(is_stream, "{path}");
+                let mut back = Vec::new();
+                comp.open_stream(&path).unwrap().read_to_end(&mut back).unwrap();
+                assert_eq!(&back, content, "{path}");
+            }
+            Some(None) => assert!(!is_stream, "{path}"),
+            None => panic!("unexpected entry {path}"),
+        }
+    }
+    assert_eq!(found, model.len(), "entry count");
+});

--- a/src/internal/stream.rs
+++ b/src/internal/stream.rs
@@ -1,5 +1,6 @@
 use crate::internal::{consts, MiniAllocator, ObjType, SectorInit};
 use std::convert::TryFrom;
+use std::fmt;
 use std::io::{self, BufRead, Read, Seek, SeekFrom, Write};
 use std::sync::{Arc, RwLock, Weak};
 
@@ -358,6 +359,16 @@ impl<F: Read + Write + Seek> Write for Stream<F> {
         let minialloc = self.minialloc()?;
         minialloc.write().unwrap().flush()?;
         Ok(())
+    }
+}
+
+impl<F> fmt::Debug for Stream<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Stream")
+            .field("stream_id", &self.stream_id)
+            .field("len", &self.total_len)
+            .field("position", &self.current_position())
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -702,6 +702,23 @@ impl<F: Read + Seek> CompoundFile<F> {
     }
 }
 
+impl<F> CompoundFile<F> {
+    /// Returns the stream ID of the storage at the given name chain, which
+    /// a new entry is about to be created in.
+    fn parent_storage_id(&self, names: &[&str]) -> io::Result<u32> {
+        let Some(parent_id) = self.stream_id_for_name_chain(names) else {
+            not_found!("Parent storage doesn't exist");
+        };
+        if self.minialloc().dir_entry(parent_id).obj_type == ObjType::Stream {
+            invalid_input!(
+                "Parent {:?} is a stream, not a storage",
+                internal::path::path_from_name_chain(names)
+            );
+        }
+        Ok(parent_id)
+    }
+}
+
 impl<F: Read + Write + Seek> CompoundFile<F> {
     /// Creates a new compound file with no contents, using the underlying
     /// reader/writer.  The reader/writer should be initially empty.
@@ -827,10 +844,7 @@ impl<F: Read + Write + Seek> CompoundFile<F> {
         // the root always already exists and will have been rejected above.
         debug_assert!(!names.is_empty());
         let name = names.pop().unwrap();
-        let parent_id = match self.stream_id_for_name_chain(&names) {
-            Some(stream_id) => stream_id,
-            None => not_found!("Parent storage doesn't exist"),
-        };
+        let parent_id = self.parent_storage_id(&names)?;
         self.minialloc_mut().insert_dir_entry(
             parent_id,
             name,
@@ -1010,10 +1024,7 @@ impl<F: Read + Write + Seek> CompoundFile<F> {
         // the root always already exists and will have been rejected above.
         debug_assert!(!names.is_empty());
         let name = names.pop().unwrap();
-        let parent_id = match self.stream_id_for_name_chain(&names) {
-            Some(stream_id) => stream_id,
-            None => not_found!("Parent storage doesn't exist"),
-        };
+        let parent_id = self.parent_storage_id(&names)?;
         let new_stream_id = self.minialloc_mut().insert_dir_entry(
             parent_id,
             name,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -786,3 +786,25 @@ fn test_compound_file_sync() {
 }
 
 //===========================================================================//
+
+/// A stream is not a storage: nothing can be created inside one, whatever
+/// case its name is spelled in.  (Doing so used to hang a child off the
+/// stream's directory entry, which strict readers reject.)
+#[test]
+fn cannot_create_entries_inside_a_stream() {
+    let cursor = Cursor::new(Vec::new());
+    let mut comp = CompoundFile::create(cursor).unwrap();
+    comp.create_stream("/a").unwrap().write_all(b"data").unwrap();
+    let err = match comp.create_stream("/A/child") {
+        Ok(_) => panic!("created a stream inside a stream"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(err.to_string(), "Parent \"/A\" is a stream, not a storage");
+    let err = comp.create_storage("/a/child").unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    let cursor = comp.into_inner();
+    let comp = CompoundFile::open_strict(cursor).unwrap();
+    assert!(comp.is_stream("/a"));
+    assert!(!comp.exists("/a/child"));
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -795,10 +795,7 @@ fn cannot_create_entries_inside_a_stream() {
     let cursor = Cursor::new(Vec::new());
     let mut comp = CompoundFile::create(cursor).unwrap();
     comp.create_stream("/a").unwrap().write_all(b"data").unwrap();
-    let err = match comp.create_stream("/A/child") {
-        Ok(_) => panic!("created a stream inside a stream"),
-        Err(err) => err,
-    };
+    let err = comp.create_stream("/A/child").unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     assert_eq!(err.to_string(), "Parent \"/A\" is a stream, not a storage");
     let err = comp.create_storage("/a/child").unwrap_err();


### PR DESCRIPTION
Creating a stream or storage did not check that the parent is a storage. Names compare case-insensitively, so with a stream `a` in the root, `create_stream("/A/child")` hung the new entry off the stream's directory entry as a child, which strict validation (and other readers) reject.

`create_stream`, `create_new_stream` and `create_storage` now fail with `InvalidInput` when the parent is a stream.

Found by the new `fuzz_write` target in the second commit, which drives the write API and reopens the result under strict validation; it runs clean with the fix.
