### PR TITLE
perf: read and write large requests past the stream buffer

### DIFF
--- a/src/internal/stream.rs
+++ b/src/internal/stream.rs
@@ -1,10 +1,20 @@
 use crate::internal::{consts, MiniAllocator, ObjType, SectorInit};
+use std::convert::TryFrom;
 use std::io::{self, BufRead, Read, Seek, SeekFrom, Write};
 use std::sync::{Arc, RwLock, Weak};
 
 //===========================================================================//
 
 use crate::internal::stream_buffer::StreamBuffer;
+
+/// Reads and writes at least this large go straight to the underlying file
+/// rather than through the stream's buffer: copying them through the buffer
+/// (and growing it to hold them) costs more than the buffering saves.
+const DIRECT_IO_MIN: usize = 64 * 1024;
+
+/// How much of a stream `read_to_end` reads per call to the underlying
+/// file.
+const READ_TO_END_CHUNK: usize = 16 * 1024 * 1024;
 
 //===========================================================================//
 
@@ -100,6 +110,27 @@ impl<F: Read + Write + Seek> Stream<F> {
     }
 }
 
+impl<F: Read + Seek> Stream<F> {
+    /// Reads into `buf` straight from the underlying file, from the current
+    /// position on.  The buffer must hold no unread data; it is emptied.
+    fn read_direct(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        debug_assert!(!self.buffer.has_remaining());
+        self.flush_changes()?;
+        let position = self.current_position();
+        self.buf_offset_from_start = position;
+        self.buffer.clear();
+        let minialloc = self.minialloc()?;
+        let num_bytes = read_data_from_stream(
+            &mut minialloc.write().unwrap(),
+            self.stream_id,
+            position,
+            buf,
+        )?;
+        self.buf_offset_from_start += num_bytes as u64;
+        Ok(num_bytes)
+    }
+}
+
 impl<F: Read + Seek> BufRead for Stream<F> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         if !self.buffer.has_remaining()
@@ -130,10 +161,75 @@ impl<F: Read + Seek> BufRead for Stream<F> {
 
 impl<F: Read + Seek> Read for Stream<F> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.len() >= DIRECT_IO_MIN && !self.buffer.has_remaining() {
+            return self.read_direct(buf);
+        }
         let mut buffered_data = self.fill_buf()?;
         let num_bytes = buffered_data.read(buf)?;
         self.consume(num_bytes);
         Ok(num_bytes)
+    }
+
+    /// Reads the rest of the stream straight into `buf`, which is grown
+    /// once to the exact size needed.
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        let buffered = self.buffer.remaining_slice();
+        let buffered_len = buffered.len();
+        buf.extend_from_slice(buffered);
+        self.buffer.consume(buffered_len);
+        let position = self.current_position();
+        debug_assert!(position <= self.total_len);
+        let remaining =
+            usize::try_from(self.total_len - position).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::OutOfMemory,
+                    "stream is too large to read into memory",
+                )
+            })?;
+        // A malformed file can claim any length for a stream; the chain
+        // behind it bounds what can actually be read, so reserve no more
+        // than that.
+        let capacity = {
+            let minialloc = self.minialloc()?;
+            let capacity = stream_capacity(
+                &mut minialloc.write().unwrap(),
+                self.stream_id,
+            )?;
+            usize::try_from(capacity.saturating_sub(position))
+                .unwrap_or(usize::MAX)
+        };
+        buf.try_reserve(remaining.min(capacity)).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::OutOfMemory,
+                "not enough memory to read the stream",
+            )
+        })?;
+        // The reserved memory is filled a piece at a time, so that a
+        // malformed file claiming an enormous stream length doesn't cost a
+        // zero fill of all of it before the read fails.
+        let mut total = 0;
+        while total < remaining {
+            // Past the chain's capacity, a one byte read reports the
+            // short chain without growing the buffer any further.
+            let chunk = (remaining - total)
+                .min(READ_TO_END_CHUNK)
+                .min(capacity.saturating_sub(total).max(1));
+            let start = buf.len();
+            buf.resize(start + chunk, 0);
+            let num_bytes = match self.read_direct(&mut buf[start..]) {
+                Ok(num_bytes) => num_bytes,
+                Err(error) => {
+                    buf.truncate(start);
+                    return Err(error);
+                }
+            };
+            buf.truncate(start + num_bytes);
+            if num_bytes == 0 {
+                break;
+            }
+            total += num_bytes;
+        }
+        Ok(buffered_len + total)
     }
 }
 
@@ -212,8 +308,33 @@ impl<F: Read + Seek> Seek for Stream<F> {
     }
 }
 
+impl<F: Read + Write + Seek> Stream<F> {
+    /// Writes `buf` straight to the underlying file at the current
+    /// position, after flushing whatever the buffer holds; the buffer is
+    /// emptied.
+    fn write_direct(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.flush_changes()?;
+        let position = self.current_position();
+        self.buf_offset_from_start = position;
+        self.buffer.clear();
+        let minialloc = self.minialloc()?;
+        write_data_to_stream(
+            &mut minialloc.write().unwrap(),
+            self.stream_id,
+            position,
+            buf,
+        )?;
+        self.buf_offset_from_start = position + buf.len() as u64;
+        self.total_len = self.total_len.max(self.buf_offset_from_start);
+        Ok(buf.len())
+    }
+}
+
 impl<F: Read + Write + Seek> Write for Stream<F> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.len() >= DIRECT_IO_MIN {
+            return self.write_direct(buf);
+        }
         let num_bytes_written = match self.buffer.write_bytes(buf) {
             Some(count) => count,
             None => {
@@ -272,6 +393,26 @@ impl<F: Read + Write + Seek> Flusher<F> for FlushBuffer {
 }
 
 //===========================================================================//
+
+/// The number of bytes the chain behind the stream can hold, which bounds
+/// what a read can return however long the directory entry claims the
+/// stream is.
+fn stream_capacity<F: Read + Seek>(
+    minialloc: &mut MiniAllocator<F>,
+    stream_id: u32,
+) -> io::Result<u64> {
+    let (start_sector, stream_len) = {
+        let dir_entry = minialloc.dir_entry(stream_id);
+        (dir_entry.start_sector, dir_entry.stream_len)
+    };
+    if start_sector == consts::END_OF_CHAIN {
+        Ok(0)
+    } else if stream_len < consts::MINI_STREAM_CUTOFF as u64 {
+        Ok(minialloc.open_mini_chain(start_sector)?.len())
+    } else {
+        Ok(minialloc.open_chain(start_sector, SectorInit::Zero)?.len())
+    }
+}
 
 fn read_data_from_stream<F: Read + Seek>(
     minialloc: &mut MiniAllocator<F>,

--- a/tests/stream_direct_io.rs
+++ b/tests/stream_direct_io.rs
@@ -1,0 +1,150 @@
+use cfb::CompoundFile;
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+
+fn pattern(len: usize, seed: u32) -> Vec<u8> {
+    (0..len as u32)
+        .map(|i| (i.wrapping_mul(2654435761) ^ seed) as u8)
+        .collect()
+}
+
+/// Large writes (which bypass the stream's buffer) and small ones (which
+/// go through it) can be mixed freely, including a large write into the
+/// middle of a stream; everything reads back the same, whether read in
+/// large pieces, small pieces, or all at once.
+#[test]
+fn large_and_small_writes_and_reads_mix() {
+    let mut comp = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    let big = pattern(300 * 1024, 1);
+    let small = pattern(1000, 2);
+    let mut expected = Vec::new();
+    {
+        let mut stream = comp.create_stream("/s").unwrap();
+        stream.write_all(&small).unwrap();
+        expected.extend_from_slice(&small);
+        stream.write_all(&big).unwrap();
+        expected.extend_from_slice(&big);
+        stream.write_all(&small).unwrap();
+        expected.extend_from_slice(&small);
+        stream.write_all(&big).unwrap();
+        expected.extend_from_slice(&big);
+        assert_eq!(stream.len(), expected.len() as u64);
+        // A large write into the middle, right after a small one.
+        stream.seek(SeekFrom::Start(500)).unwrap();
+        let patch_small = pattern(100, 3);
+        stream.write_all(&patch_small).unwrap();
+        expected[500..600].copy_from_slice(&patch_small);
+        let patch_big = pattern(100 * 1024, 4);
+        stream.write_all(&patch_big).unwrap();
+        expected[600..600 + patch_big.len()].copy_from_slice(&patch_big);
+        assert_eq!(stream.len(), expected.len() as u64);
+    }
+    let check = |comp: &mut CompoundFile<Cursor<Vec<u8>>>| {
+        let mut stream = comp.open_stream("/s").unwrap();
+        let mut all = Vec::new();
+        stream.read_to_end(&mut all).unwrap();
+        assert_eq!(all, expected);
+        assert_eq!(stream.read_to_end(&mut all).unwrap(), 0);
+        stream.seek(SeekFrom::Start(0)).unwrap();
+        let mut in_pieces = Vec::new();
+        for len in [10usize, 70 * 1024, 5, 200 * 1024, 100_000, 100] {
+            let mut piece = vec![0; len];
+            stream.read_exact(&mut piece).unwrap();
+            in_pieces.extend_from_slice(&piece);
+        }
+        assert_eq!(in_pieces, expected[..in_pieces.len()]);
+        // Reading the rest after small buffered reads hands out what the
+        // buffer holds first.
+        let mut rest = Vec::new();
+        stream.read_to_end(&mut rest).unwrap();
+        in_pieces.extend_from_slice(&rest);
+        assert_eq!(in_pieces, expected);
+    };
+    check(&mut comp);
+    let bytes = comp.into_inner().into_inner();
+    let mut comp = CompoundFile::open_strict(Cursor::new(bytes)).unwrap();
+    check(&mut comp);
+}
+
+/// Data still sitting in the stream's buffer is flushed before a direct
+/// read or write, so nothing is lost or read stale.
+#[test]
+fn buffered_writes_are_visible_to_direct_reads() {
+    let mut comp = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    let mut stream = comp.create_stream("/s").unwrap();
+    let head = pattern(3000, 5);
+    stream.write_all(&head).unwrap();
+    stream.seek(SeekFrom::Start(0)).unwrap();
+    let mut all = Vec::new();
+    stream.read_to_end(&mut all).unwrap();
+    assert_eq!(all, head);
+    // A small write followed by a large one, then a large read of both.
+    stream.seek(SeekFrom::Start(1000)).unwrap();
+    let mid = pattern(50, 6);
+    let tail = pattern(80 * 1024, 7);
+    stream.write_all(&mid).unwrap();
+    stream.write_all(&tail).unwrap();
+    let mut expected = head.clone();
+    expected.truncate(1000);
+    expected.extend_from_slice(&mid);
+    expected.extend_from_slice(&tail);
+    assert_eq!(stream.len(), expected.len() as u64);
+    stream.seek(SeekFrom::Start(0)).unwrap();
+    let mut back = vec![0; expected.len()];
+    stream.read_exact(&mut back).unwrap();
+    assert_eq!(back, expected);
+}
+
+/// A stream shorter than the direct threshold still reads back whole
+/// through `read_to_end`, from a stream in the mini stream as well.
+#[test]
+fn read_to_end_of_small_streams() {
+    let mut comp = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    let tiny = pattern(100, 8);
+    comp.create_stream("/tiny").unwrap().write_all(&tiny).unwrap();
+    comp.create_stream("/empty").unwrap();
+    let mut stream = comp.open_stream("/tiny").unwrap();
+    let mut first = [0u8; 30];
+    stream.read_exact(&mut first).unwrap();
+    let mut rest = Vec::new();
+    assert_eq!(stream.read_to_end(&mut rest).unwrap(), 70);
+    assert_eq!(rest, tiny[30..]);
+    let mut nothing = Vec::new();
+    assert_eq!(
+        comp.open_stream("/empty").unwrap().read_to_end(&mut nothing).unwrap(),
+        0
+    );
+}
+
+/// A stream longer than one `read_to_end` piece is read whole.
+#[test]
+fn read_to_end_of_a_stream_beyond_one_piece() {
+    let mut comp = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    let data = pattern(17 * 1024 * 1024 + 123, 9);
+    comp.create_stream("/s").unwrap().write_all(&data).unwrap();
+    let mut back = Vec::new();
+    comp.open_stream("/s").unwrap().read_to_end(&mut back).unwrap();
+    assert_eq!(back, data);
+}
+
+/// A directory entry may claim any length for its stream; `read_to_end`
+/// reserves no more than the stream's chain can hold, and reports the
+/// short chain as an error instead of allocating for the claim.
+#[test]
+fn read_to_end_does_not_trust_a_claimed_length() {
+    let mut comp = CompoundFile::create(Cursor::new(Vec::new())).unwrap();
+    comp.create_stream("/s").unwrap().write_all(&[7; 5000]).unwrap();
+    let mut bytes = comp.into_inner().into_inner();
+    // A new V4 file is header, FAT sector, directory sector; the stream's
+    // entry is the second one in the directory, and its length field is at
+    // offset 120 of the 128 byte entry.  Claim about 4 GB.
+    let entry = 2 * 4096 + 128;
+    assert_eq!(&bytes[entry..entry + 2], &[b's', 0]);
+    bytes[entry + 120..entry + 128]
+        .copy_from_slice(&0xFFF0_0000u64.to_le_bytes());
+    let mut comp = CompoundFile::open(Cursor::new(bytes)).unwrap();
+    let mut stream = comp.open_stream("/s").unwrap();
+    assert_eq!(stream.len(), 0xFFF0_0000);
+    let mut data = Vec::new();
+    assert!(stream.read_to_end(&mut data).is_err());
+    assert!(data.capacity() < 1 << 20, "reserved {}", data.capacity());
+}


### PR DESCRIPTION
Every read went through the stream's buffer, which each new `Stream` grew from 1 KiB up to 1 MiB (zero-filled at each step) and then copied out of, so `read_to_end` on a large stream cost a zero fill and two copies per byte plus the reallocations of the caller's vector.

Reads and writes of 64 KiB or more now go straight to the underlying file. `read_to_end` reserves the remaining length once and reads into it directly, in 16 MiB pieces. The reservation is bounded by what the stream's chain can actually hold, so a malformed file claiming an enormous length cannot make it allocate for the claim (the fuzz target caught exactly that in an earlier version).

| case (criterion) | before | after |
|---|---|---|
| read from memory, 50 x 1 MiB | 19.5 ms | 2.2 ms |
| read from memory, 1 x 256 MiB | 98 ms | 54 ms |
| read from memory, 100 x 4 KiB | 115 us | 61 us |

Tests: mixed large and small reads and writes including a large write into the middle of a stream; buffered writes visible to a following direct read; `read_to_end` of small and mini streams, of a stream longer than one piece, and of a stream whose entry claims about 4 GB (must fail without reserving for it).
