### PR TITLE
fix: zero the bytes past a stream's length when it shrinks or grows

### DIFF
--- a/src/internal/chain.rs
+++ b/src/internal/chain.rs
@@ -67,7 +67,7 @@ impl<'a, F: Write + Seek> Chain<'a, F> {
                 self.allocator
                     .free_chain_after(self.sector_ids[new_num_sectors - 1])?;
             }
-            // TODO: init remainder of final sector
+            self.zero_tail(new_len)?;
         } else {
             for _ in self.sector_ids.len()..new_num_sectors {
                 let new_sector_id = if let Some(&last_sector_id) =
@@ -81,6 +81,23 @@ impl<'a, F: Write + Seek> Chain<'a, F> {
             }
         }
         Ok(())
+    }
+
+    /// Overwrites with zeros the bytes from `offset` to the end of the sector
+    /// containing it, so that no stale data lingers past a stream's length.
+    /// Does nothing if `offset` is at the start of a sector.
+    pub fn zero_tail(&mut self, offset: u64) -> io::Result<()> {
+        let sector_len = self.allocator.sector_len() as u64;
+        let offset_within_sector = offset % sector_len;
+        if offset_within_sector == 0 {
+            return Ok(());
+        }
+        debug_assert!(offset < self.len());
+        let sector_id = self.sector_ids[(offset / sector_len) as usize];
+        let zeros = vec![0u8; (sector_len - offset_within_sector) as usize];
+        self.allocator
+            .seek_within_sector(sector_id, offset_within_sector)?
+            .write_all(&zeros)
     }
 
     pub fn free(self) -> io::Result<()> {

--- a/src/internal/minialloc.rs
+++ b/src/internal/minialloc.rs
@@ -396,6 +396,14 @@ impl<F: Write + Seek> MiniAllocator<F> {
             invalid_input!("sector {} freed twice", mini_sector);
         }
         self.set_minifat(mini_sector, consts::FREE_SECTOR)?;
+        // Wipe the mini sector now.  Regular sectors are zeroed when they
+        // are allocated, but a mini sector can come back into use without
+        // passing through allocation of a fresh sector: either from the
+        // free list, or by the mini stream growing again over a region it
+        // was truncated from below.  A chain growing into it must read
+        // zeros there.
+        self.seek_within_mini_sector(mini_sector, 0)?
+            .write_all(&[0u8; consts::MINI_SECTOR_LEN])?;
         self.free_mini_sectors.push(mini_sector);
         let mut mini_stream_len = self.directory.root_dir_entry().stream_len;
         debug_assert_eq!(mini_stream_len % consts::MINI_SECTOR_LEN as u64, 0);

--- a/src/internal/minichain.rs
+++ b/src/internal/minichain.rs
@@ -58,7 +58,7 @@ impl<'a, F: Read + Write + Seek> MiniChain<'a, F> {
                     self.sector_ids[new_num_sectors - 1],
                 )?;
             }
-            // TODO: zero remainder of final sector
+            self.zero_tail(new_len)?;
         } else {
             for _ in self.sector_ids.len()..new_num_sectors {
                 let new_sector_id =
@@ -71,6 +71,23 @@ impl<'a, F: Read + Write + Seek> MiniChain<'a, F> {
             }
         }
         Ok(())
+    }
+
+    /// Overwrites with zeros the bytes from `offset` to the end of the mini
+    /// sector containing it, so that no stale data lingers past a stream's
+    /// length.  Does nothing if `offset` is at the start of a mini sector.
+    pub fn zero_tail(&mut self, offset: u64) -> io::Result<()> {
+        let sector_len = consts::MINI_SECTOR_LEN as u64;
+        let offset_within_sector = offset % sector_len;
+        if offset_within_sector == 0 {
+            return Ok(());
+        }
+        debug_assert!(offset < self.len());
+        let sector_id = self.sector_ids[(offset / sector_len) as usize];
+        let zeros = vec![0u8; (sector_len - offset_within_sector) as usize];
+        self.minialloc
+            .seek_within_mini_sector(sector_id, offset_within_sector)?
+            .write_all(&zeros)
     }
 
     pub fn free(self) -> io::Result<()> {

--- a/src/internal/stream.rs
+++ b/src/internal/stream.rs
@@ -429,8 +429,12 @@ fn resize_stream<F: Read + Write + Seek>(
         } else if new_stream_len < consts::MINI_STREAM_CUTOFF as u64 {
             // Case 2b: The new length is still small enough to fit in a mini
             // chain.  Therefore, we just need to adjust the length of the
-            // existing chain.
+            // existing chain.  When growing, the bytes between the old and
+            // new lengths in the last mini sector must read as zeros.
             let mut chain = minialloc.open_mini_chain(old_start_sector)?;
+            if new_stream_len > old_stream_len {
+                chain.zero_tail(old_stream_len)?;
+            }
             chain.set_len(new_stream_len)?;
             debug_assert_eq!(chain.start_sector_id(), old_start_sector);
             old_start_sector
@@ -469,9 +473,13 @@ fn resize_stream<F: Read + Write + Seek>(
         } else {
             // Case 3c: The new length is still too large to fit in a mini
             // chain.  Therefore, we just need to adjust the length of the
-            // existing chain.
+            // existing chain.  When growing, the bytes between the old and
+            // new lengths in the last sector must read as zeros.
             let mut chain =
                 minialloc.open_chain(old_start_sector, SectorInit::Zero)?;
+            if new_stream_len > old_stream_len {
+                chain.zero_tail(old_stream_len)?;
+            }
             chain.set_len(new_stream_len)?;
             debug_assert_eq!(chain.start_sector_id(), old_start_sector);
             old_start_sector

--- a/tests/set_len.rs
+++ b/tests/set_len.rs
@@ -1,5 +1,5 @@
 use cfb::{CompoundFile, Version};
-use std::io::{Cursor, Read, Write};
+use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 
 //===========================================================================//
 
@@ -98,3 +98,82 @@ fn resize_huge_to_large() {
 }
 
 //===========================================================================//
+
+//===========================================================================//
+
+// Bytes past a stream's length must not survive in the last sector, or a
+// later grow would hand them back as data.
+
+fn count_byte(comp: CompoundFile<Cursor<Vec<u8>>>, byte: u8) -> usize {
+    comp.into_inner().get_ref().iter().filter(|&&b| b == byte).count()
+}
+
+fn fill_and_shrink(
+    initial_len: usize,
+    shrunk_len: usize,
+) -> CompoundFile<Cursor<Vec<u8>>> {
+    let mut comp =
+        CompoundFile::create(Cursor::new(Vec::new())).expect("create");
+    comp.create_stream("/s")
+        .unwrap()
+        .write_all(&vec![0xAB; initial_len])
+        .unwrap();
+    comp.open_stream("/s").unwrap().set_len(shrunk_len as u64).unwrap();
+    comp
+}
+
+fn read_tail(
+    comp: &mut CompoundFile<Cursor<Vec<u8>>>,
+    from: usize,
+) -> Vec<u8> {
+    let mut stream = comp.open_stream("/s").unwrap();
+    stream.seek(SeekFrom::Start(from as u64)).unwrap();
+    let mut tail = Vec::new();
+    stream.read_to_end(&mut tail).unwrap();
+    tail
+}
+
+#[test]
+fn shrink_zeroes_the_rest_of_the_last_sector() {
+    assert_eq!(count_byte(fill_and_shrink(5000, 4100), 0xAB), 4100);
+    assert_eq!(count_byte(fill_and_shrink(200, 100), 0xAB), 100);
+}
+
+#[test]
+fn grow_after_shrink_reads_zeros() {
+    let mut comp = fill_and_shrink(5000, 4100);
+    comp.open_stream("/s").unwrap().set_len(5000).unwrap();
+    assert_eq!(read_tail(&mut comp, 4100), vec![0u8; 900]);
+    let mut comp = fill_and_shrink(200, 100);
+    comp.open_stream("/s").unwrap().set_len(200).unwrap();
+    assert_eq!(read_tail(&mut comp, 100), vec![0u8; 100]);
+}
+
+#[test]
+fn grow_after_shrink_across_the_mini_cutoff_reads_zeros() {
+    let mut comp = fill_and_shrink(5000, 100);
+    comp.open_stream("/s").unwrap().set_len(5000).unwrap();
+    assert_eq!(read_tail(&mut comp, 100), vec![0u8; 4900]);
+}
+
+#[test]
+fn removing_a_mini_stream_leaves_no_data_behind() {
+    let mut comp =
+        CompoundFile::create(Cursor::new(Vec::new())).expect("create");
+    comp.create_stream("/s").unwrap().write_all(&[0xAB; 200]).unwrap();
+    comp.remove_stream("/s").unwrap();
+    assert_eq!(count_byte(comp, 0xAB), 0);
+}
+
+#[test]
+fn grow_in_a_reused_mini_sector_reads_zeros() {
+    let mut comp =
+        CompoundFile::create(Cursor::new(Vec::new())).expect("create");
+    comp.create_stream("/old").unwrap().write_all(&[0xAB; 128]).unwrap();
+    comp.remove_stream("/old").unwrap();
+    // The new stream takes over the freed mini sectors, whose old contents
+    // must not show up when it grows into them.
+    comp.create_stream("/s").unwrap().write_all(&[0xCD; 100]).unwrap();
+    comp.open_stream("/s").unwrap().set_len(128).unwrap();
+    assert_eq!(read_tail(&mut comp, 100), vec![0u8; 28]);
+}


### PR DESCRIPTION
Shrinking a stream and growing it again handed the old bytes back as data:

```rust
comp.create_stream("/s")?.write_all(&[0xAB; 5000])?;
comp.open_stream("/s")?.set_len(4100)?;
comp.open_stream("/s")?.set_len(5000)?;
// bytes 4100..5000 now read 0xAB, the docs promise zeros
```

Shrinking left the rest of the last sector untouched (the two `TODO: zero remainder of final sector` in `Chain` and `MiniChain`), and freed mini sectors kept their contents, so a mini stream could hit the same symptom without shrinking: the mini stream truncates trailing free mini sectors and later grows back over the same region.

- `Chain::set_len` and `MiniChain::set_len` zero the tail of the last sector when shrinking.
- A stream that grows in place zeros the gap in its last sector first, so files written by other tools or older versions read zeros too.
- Mini sectors are wiped when freed. Regular sectors are already zeroed on allocation; for mini sectors, free is the only place that sees every sector that can come back into use.

Cost is one partial sector write per shrink or in-place grow, and a 64 byte write per freed mini sector.
